### PR TITLE
Handle coins and proposals

### DIFF
--- a/lib/bmultisig.js
+++ b/lib/bmultisig.js
@@ -82,6 +82,8 @@ class Plugin extends EventEmitter {
       this.logError(err);
       this.emit('error', err);
     });
+
+    this.msdb.init();
   }
 
   async open() {

--- a/lib/multisigdb.js
+++ b/lib/multisigdb.js
@@ -44,6 +44,17 @@ class MultisigDB extends EventEmitter {
   }
 
   /**
+   * Listen for necessary events
+   * @private
+   */
+
+  init() {
+    this.client.on('error', (error) => {
+      this.emit('error', error);
+    });
+  }
+
+  /**
    * Open MultisigDB
    * @returns {Promise}
    */
@@ -54,7 +65,9 @@ class MultisigDB extends EventEmitter {
     await this.db.verify(layout.V.build(), 'multisig', 0);
     await this.verifyNetwork();
 
-    this.logger.info('MultisigDB loaded');
+    await this.client.open();
+
+    this.logger.info('MultisigDB loaded.');
   }
 
   /**
@@ -69,6 +82,7 @@ class MultisigDB extends EventEmitter {
     }
 
     await this.db.close();
+    await this.client.close();
   }
 
   /**
@@ -80,6 +94,8 @@ class MultisigDB extends EventEmitter {
     const raw = await this.db.get(layout.O.build());
 
     if (!raw) {
+      this.logger.debug('Creating MultisigDB.');
+
       const b = this.db.batch();
       b.put(layout.O.build(), fromU32(this.network.magic));
       return b.write();

--- a/lib/multisigdb.js
+++ b/lib/multisigdb.js
@@ -52,6 +52,36 @@ class MultisigDB extends EventEmitter {
     this.client.on('error', (error) => {
       this.emit('error', error);
     });
+
+    this.client.on('tx', async (wallet, tx, details) => {
+      const wid = wallet.wid;
+      const mswallet = await this.get(wid);
+
+      if (!mswallet)
+        return;
+
+      await mswallet.addTX(tx, details);
+    });
+
+    this.client.on('confirmed', async (wallet, tx, details) => {
+      const wid = wallet.wid;
+      const mswallet = await this.get(wid);
+
+      if (!mswallet)
+        return;
+
+      await mswallet.confirmedTX(tx, details);
+    });
+
+    this.client.on('remove tx', async (wallet, tx, details) => {
+      const wid = wallet.wid;
+      const mswallet = await this.get(wid);
+
+      if (!mswallet)
+        return;
+
+      await mswallet.removeTX(tx, details);
+    });
   }
 
   /**

--- a/lib/proposal.js
+++ b/lib/proposal.js
@@ -13,27 +13,39 @@ const {Outpoint, TX} = bcoin;
 const Cosigner = require('./cosigner');
 const layout = require('./layout').proposaldb;
 
+/**
+ * Proposal status
+ * @readonly
+ * @enum {Number}
+ */
 const status = {
   PROGRESS: 0,
-  APPROVED: 1,
-  REJECTED: 2,
-  REORG: 3,
-  VERIFY: 4
+
+  // approved
+  APPROVED: 1,  // transaction was approved (broadcast)
+
+  // rejection reasons
+  REJECTED: 2,  // user rejected
+  DBLSPEND: 3,  // double spend
+  VERIFY: 4     // transaction verification failure
 };
 
 const statusByVal = [
   'PROGRESS',
   'APPROVED',
+
   'REJECTED',
-  'REORG',
+  'DBLSPEND',
   'VERIFY'
 ];
 
 const statusMessages = [
   'Proposal is in progress.',
+
   'Proposal has been approved.',
+
   'Cosigners rejected the proposal.',
-  'Block reorg invalidated coins.',
+  'Coins used in the proposal were double spent',
   'Rejected due to non-signed transaction.'
 ];
 
@@ -284,7 +296,8 @@ class Proposal extends Struct {
   isRejected() {
     return this.status === status.REORG
       || this.status === status.REJECTED
-      || this.status === status.VERIFY;
+      || this.status === status.VERIFY
+      || this.status === status.DBLSPEND;
   }
 
   /**
@@ -337,6 +350,19 @@ class Proposal extends Struct {
 
     this.rejections.push(cosigner.id);
     this.updateStatus();
+  }
+
+  /**
+   * Reject proposal with status
+   * @param {status} status
+   * @throws {Error}
+   */
+
+  forceReject(status) {
+    assert(this.isPending(), 'Can not reject non pending proposal.');
+    this.status = status;
+
+    assert(this.isRejected(), 'status needs to be rejection.');
   }
 
   /**

--- a/lib/proposal.js
+++ b/lib/proposal.js
@@ -251,6 +251,23 @@ class Proposal extends Struct {
    */
 
   /**
+   * Check proposal equality
+   * @param {Proposal} proposal
+   * @returns {Boolean}
+   */
+
+  equals(proposal) {
+    return this.id === proposal.id
+      && this.name === proposal.name
+      && this.m === proposal.m
+      && this.n === proposal.n
+      && this.author === proposal.author
+      && this.status === proposal.status
+      && arrayEquals(this.approvals, proposal.approvals)
+      && arrayEquals(this.rejections, proposal.rejections);
+  }
+
+  /**
    * Check if status is pending
    * @returns {Boolean}
    */
@@ -614,6 +631,17 @@ function isU32(number) {
 
 function isU8(number) {
   return (number & 0xff) === number;
+}
+
+function arrayEquals(arr1, arr2) {
+  if (arr1.length !== arr2.length)
+    return false;
+
+  for (let i = 0; i < arr1.length; i++)
+    if (arr1[i] !== arr2[i])
+      return false;
+
+  return true;
 }
 
 /*

--- a/lib/proposal.js
+++ b/lib/proposal.js
@@ -505,18 +505,19 @@ class Proposal extends Struct {
   }
 
   /**
-   * Get proposal by coin
+   * Get proposal id by coin
    * @param {Outpoint} outpoint
    * @returns {Promise<Number>}
    */
 
   static async getPIDByOutpoint(db, outpoint) {
-    const pid = await this.get(layout.P.build(outpoint.hash, outpoint.index));
+    const pid = await db.get(layout.P.build(outpoint.hash, outpoint.index));
 
     if (!pid)
       return -1;
 
-    return pid;
+    assert(pid.length === 4);
+    return pid.readUInt32LE(0, true);
   }
 
   /*
@@ -584,6 +585,16 @@ class Proposal extends Struct {
       b.del(layout.e.build(pid));
       b.put(layout.f.build(pid));
     }
+  }
+
+  /**
+   * Save proposal id by coin
+   * @param {Coin} coin
+   * @param {Number} pid
+   */
+
+  static savePIDByCoin(b, coin, pid) {
+    b.put(layout.P.build(coin.hash, coin.index), fromU32(pid));
   }
 }
 

--- a/lib/proposal.js
+++ b/lib/proposal.js
@@ -613,6 +613,15 @@ class Proposal extends Struct {
   static savePIDByCoin(b, coin, pid) {
     b.put(layout.P.build(coin.hash, coin.index), fromU32(pid));
   }
+
+  /**
+   * Remove proposal id by coin mapping
+   * @param {Coin|Outpoint} coin
+   */
+
+  static removePIDByCoin(b, coin) {
+    b.del(layout.P.build(coin.hash, coin.index));
+  }
 }
 
 /*

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -346,6 +346,10 @@ class ProposalDB {
 
     for (const input of mtx.inputs) {
       const coin = mtx.view.getCoinFor(input);
+
+      if (!coin)
+        continue;
+
       this.lockCoin(b, proposal, coin);
       Proposal.savePIDByCoin(b, coin, proposal.id);
     }

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -247,14 +247,14 @@ class ProposalDB {
   }
 
   /**
-   * Get proposal by coin
+   * Get proposal by coin/outpoint
    * @async
    * @param {Outpoint} outpoint
    * @returns {Promise<Proposal?>}
    */
 
   async getProposalByOutpoint(outpoint) {
-    const pid = await Proposal.getPIDByOutpoint(this.bucket, outpoint);
+    const pid = await this.getPIDByOutpoint(outpoint);
 
     if (pid === -1)
       return null;
@@ -263,6 +263,17 @@ class ProposalDB {
     proposal.m = this.wallet.m;
     proposal.n = this.wallet.n;
     return proposal;
+  }
+
+  /**
+   * Get proposal ID by coin, outpoint
+   * @async
+   * @param {Outpoint} outpoint
+   * @returns {Promise<Number>} Proposal ID
+   */
+
+  getPIDByOutpoint(outpoint) {
+    return Proposal.getPIDByOutpoint(this.bucket, outpoint);
   }
 
   /**
@@ -336,6 +347,7 @@ class ProposalDB {
     for (const input of mtx.inputs) {
       const coin = mtx.view.getCoinFor(input);
       this.lockCoin(b, proposal, coin);
+      Proposal.savePIDByCoin(b, coin, proposal.id);
     }
 
     Proposal.saveProposalWithTX(b, proposal);

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -508,6 +508,48 @@ class ProposalDB {
     return proposal;
   }
 
+  /**
+   * Reject proposal if it is pending
+   * Used to reject double spent proposals
+   * @private
+   * @param {Number} pid
+   */
+
+  async rejectPending(pid) {
+    const unlock1 = await this.readLock.lock(pid);
+    const unlock2 = await this.writeLock.lock();
+
+    try {
+      await this._rejectPending(pid);
+    } finally {
+      unlock1();
+      unlock2();
+    }
+  }
+
+  async _rejectPending(pid) {
+    const proposal = await this._get(pid);
+
+    if (!proposal || !proposal.isPending())
+      return;
+
+    proposal.forceReject(Proposal.status.DBLSPEND);
+
+    const outpoints = await Proposal.getProposalOutpoints(this.bucket, pid);
+    const b = this.bucket.batch();
+
+    for (const outpoint of outpoints) {
+      this.unlockCoin(b, proposal, outpoint);
+      Proposal.removePIDByCoin(b, outpoint);
+    }
+
+    Proposal.saveProposal(b, proposal);
+
+    await b.write();
+
+    return;
+  }
+
   /*
    * layout
    */

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -7,7 +7,7 @@
 'use strict';
 
 const assert = require('assert');
-const {CoinView, MTX} = require('bcoin');
+const {Outpoint, CoinView, MTX} = require('bcoin');
 const Proposal = require('./proposal');
 const {MapLock, Lock} = require('bmutex');
 const layout = require('./layout').proposaldb;
@@ -599,6 +599,30 @@ class ProposalDB {
 
   confirmedTX(tx, details) {
     return this.rejectProposalByTX(tx);
+  }
+
+  /**
+   * Transaction was removed.
+   * Check if we have coins in removed transaction.
+   * Reject proposal if necessary.
+   * @private
+   * @param {bcoin#TX} tx
+   * @param {bcoin#TXDB#Details} details
+   */
+
+  async removeTX(tx, details) {
+    const pids = new Set();
+
+    for (let i = 0; i < tx.outputs.length; i++) {
+      const outpoint = Outpoint.fromTX(tx, i);
+      const pid = await this.getPIDByOutpoint(outpoint);
+
+      if (pid !== -1)
+        pids.add(pid);
+    }
+
+    for (const pid of pids)
+      await this.rejectPending(pid);
   }
 
   /*

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -575,6 +575,32 @@ class ProposalDB {
       await this.rejectPending(pid);
   }
 
+  /**
+   * Transaction was added in mempool or chain.
+   * Check if we have proposal using same Coins.
+   * reject if necessary.
+   * @private
+   * @param {bcoin#TX} tx
+   * @param {bcoin#TXDB#Details} details
+   */
+
+  addTX(tx, details) {
+    return this.rejectProposalByTX(tx);
+  }
+
+  /**
+   * Transaction was confirmed.
+   * Check if we have proposal using same Coins.
+   * reject if necessary.
+   * @private
+   * @param {bcoin#TX} tx
+   * @param {bcoin#TXDB#Details} details
+   */
+
+  confirmedTX(tx, details) {
+    return this.rejectProposalByTX(tx);
+  }
+
   /*
    * layout
    */

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -510,7 +510,7 @@ class ProposalDB {
 
   /**
    * Reject proposal if it is pending
-   * Used to reject double spent proposals
+   * rejects double spent proposals
    * @private
    * @param {Number} pid
    */
@@ -548,6 +548,31 @@ class ProposalDB {
     await b.write();
 
     return;
+  }
+
+  /**
+   * Reject proposals if transaction
+   * contains same coins and proposal
+   * is pending
+   * @private
+   * @param {TX} tx
+   */
+
+  async rejectProposalByTX(tx) {
+    if (tx.isCoinbase())
+      return;
+
+    const pids = new Set();
+
+    for (const {prevout} of tx.inputs) {
+      const pid = await this.getPIDByOutpoint(prevout);
+
+      if (pid !== -1)
+        pids.add(pid);
+    }
+
+    for (const pid of pids)
+      await this.rejectPending(pid);
   }
 
   /*

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -278,11 +278,16 @@ class ProposalDB {
 
   /**
    * Get proposal coins (use only on pending proposals)
-   * @param {pid} pid
+   * @param {Number|String} id
    * @throws {Error}
    */
 
-  async getProposalCoins(pid) {
+  async getProposalCoins(id) {
+    const pid = await this.ensurePID(id);
+
+    if (pid === -1)
+      return null;
+
     const outpoints = await Proposal.getProposalOutpoints(this.bucket, pid);
     const coins = [];
 
@@ -408,8 +413,10 @@ class ProposalDB {
     const outpoints = await Proposal.getProposalOutpoints(this.bucket, pid);
     const b = this.bucket.batch();
 
-    for (const outpoint of outpoints)
+    for (const outpoint of outpoints) {
       this.unlockCoin(b, proposal, outpoint);
+      Proposal.removePIDByCoin(b, outpoint);
+    }
 
     Proposal.saveProposal(b, proposal);
 

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -647,6 +647,16 @@ class MultisigWallet {
   }
 
   /**
+   * Get proposal coins
+   * @param {String|Number} id
+   * @returns {Promise<Coin[]?>}
+   */
+
+  getProposalCoins(pid) {
+    return this.pdb.getProposalCoins(pid);
+  }
+
+  /**
    * Get proposal by outpoint/coin
    * @async
    * @param {Outpoint|Coin} outpoint

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -647,6 +647,28 @@ class MultisigWallet {
   }
 
   /**
+   * Get proposal by outpoint/coin
+   * @async
+   * @param {Outpoint|Coin} outpoint
+   * @returns {Promise<Proposal?>}
+   */
+
+  getProposalByOutpoint(outpoint) {
+    return this.pdb.getProposalByOutpoint(outpoint);
+  }
+
+  /**
+   * Get proposal id by Outpoint/Coin
+   * @async
+   * @param {Outpoint|Coin} outpoint
+   * @returns {Promise<Number>} - proposal id
+   */
+
+  getPIDByOutpoint(outpoint) {
+    return this.pdb.getPIDByOutpoint(outpoint);
+  }
+
+  /**
    * Get coin by outpoint
    * @param {Hash} hash
    * @param {Number} index

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -788,6 +788,46 @@ class MultisigWallet {
   send(mtx) {
     return this.msdb.send(mtx);
   }
+
+  /*
+   * Next TX related methods
+   * Notify ProposalDB on new transactions
+   * potentially unlocks some coins
+   * and/or rejects proposals
+   */
+
+  /**
+   * Transaction was added mempool or in chain
+   * @param {bcoin#TX} tx
+   * @returns {Promise}
+   */
+
+  addTX(tx, details) {
+    return this.pdb.addTX(tx, details);
+  }
+
+  /**
+   * Transaction was removed, it
+   * was double spent
+   * @param {bcoin#TX} tx
+   * @param {bcoin#txdb#Details} details
+   * @returns {Promise}
+   */
+
+  removeTX(tx, details) {
+    return this.pdb.removeTX(tx, details);
+  }
+
+  /**
+   * Transaction was confirmed in the block.
+   * @param {bcoin#TX} tx
+   * @param {bcoin#txdb#Details} details
+   * @returns {Promise}
+   */
+
+  confirmedTX(tx, details) {
+    return this.pdb.confirmedTX(tx, details);
+  }
 }
 
 /*

--- a/lib/walletclient.js
+++ b/lib/walletclient.js
@@ -7,13 +7,13 @@
 'use strict';
 
 const assert = require('assert');
-const EventEmitter = require('events');
+const AsyncEmitter = require('bevent');
 
 /**
  * Wallet node client
  */
 
-class WalletNodeClient extends EventEmitter {
+class WalletNodeClient extends AsyncEmitter {
   /**
    * Create wallet node client
    * @constructor
@@ -27,6 +27,8 @@ class WalletNodeClient extends EventEmitter {
     this.wdb = node.wdb;
 
     this.opened = false;
+
+    this.init();
   }
 
   /**
@@ -34,7 +36,35 @@ class WalletNodeClient extends EventEmitter {
    * @private
    */
 
-  init() {}
+  init() {
+    this.wdb.on('tx', (wallet, tx, details) => {
+      if (!this.opened)
+        return;
+
+      this.emitAsync('tx', wallet, tx, details);
+    });
+
+    this.wdb.on('confirmed', (wallet, tx, details) => {
+      if (!this.opened)
+        return;
+
+      this.emitAsync('confirmed', wallet, tx, details);
+    });
+
+    this.wdb.on('remove tx', (wallet, tx, details) => {
+      if (!this.opened)
+        return;
+
+      this.emitAsync('remove tx', wallet, tx, details);
+    });
+
+    this.wdb.on('unconfirmed', (wallet, tx, details) => {
+      if (!this.opened)
+        return;
+
+      this.emitAsync('unconfirmed', wallet, tx, details);
+    });
+  }
 
   /**
    * Open connection to wallet node

--- a/lib/walletnullclient.js
+++ b/lib/walletnullclient.js
@@ -1,0 +1,115 @@
+/*!
+ * walletnullclient.js - Wallet Node Client
+ * Copyright (c) 2018, The Bcoin Developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+const assert = require('assert');
+const EventEmitter = require('events');
+
+/**
+ * Wallet node client
+ */
+
+class WalletNodeClient extends EventEmitter {
+  /**
+   * Create wallet node client
+   * @constructor
+   */
+
+  constructor() {
+    super();
+
+    this.opened = false;
+    this.init();
+  }
+
+  /**
+   * Setup event listeners
+   * @private
+   */
+
+  init() {}
+
+  /**
+   * Open connection to wallet node
+   * @returns {Promise}
+   */
+
+  async open() {
+    assert(!this.opened, 'WalletNodeClient is already open.');
+    this.opened = true;
+    this.emit('connect');
+  }
+
+  /**
+   * Close connection to wallet node
+   * @returns {Promise}
+   */
+
+  async close() {
+    assert(this.opened, 'WalletNodeClient is not open.');
+    this.opened = false;
+    this.emit('disconnect');
+  }
+
+  /**
+   * Create wallet
+   * @param {Object} options
+   * @returns {Promise<bcoin.Wallet>}
+   * @throws {Error}
+   */
+
+  async create(options) {
+    ;
+  }
+
+  /**
+   * Delete wallet
+   * @param {Number|String} id
+   * @returns {Promise<Boolean>}
+   * @throws {Error}
+   */
+
+  async remove(id) {
+    return false;
+  }
+
+  /**
+   * Get Wallet
+   * @param {Number|String} id
+   * @returns {Promise<Wallet>}
+   * @throws {Error}
+   */
+
+  async get(id) {
+    ;
+  }
+
+  /**
+   * Get list of wallets
+   * @returns {Promise<String[]>}
+   */
+
+  async getWallets() {
+    return [];
+  }
+
+  /**
+   * @async
+   * @param {MTX} mtx
+   * @returns {Promise}
+   */
+
+  async send(mtx) {
+    ;
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = WalletNodeClient;

--- a/package-lock.json
+++ b/package-lock.json
@@ -613,14 +613,14 @@
       }
     },
     "chalk": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+      "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "5.3.0"
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -633,9 +633,9 @@
           }
         },
         "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -952,7 +952,7 @@
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.3.2",
+        "chalk": "2.4.0",
         "concat-stream": "1.6.2",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
@@ -1374,7 +1374,7 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "3.1.0",
-        "chalk": "2.3.2",
+        "chalk": "2.4.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
@@ -1740,7 +1740,7 @@
         "bindings": "1.3.0",
         "fast-future": "1.0.2",
         "nan": "2.8.0",
-        "prebuild-install": "2.5.2"
+        "prebuild-install": "2.5.3"
       },
       "dependencies": {
         "nan": {
@@ -2084,9 +2084,9 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.2.tgz",
-      "integrity": "sha512-/KVYCewcfs20kkwifbTAk+3LVr79h4+E+TQG+MtK26Yh632jUJcJOTy6MX4MtE6xHpsGMEtQ8oxDRVJH333dag==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
+      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
       "requires": {
         "detect-libc": "1.0.3",
         "expand-template": "1.1.0",
@@ -2457,7 +2457,7 @@
       "requires": {
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "chalk": "2.3.2",
+        "chalk": "2.4.0",
         "lodash": "4.17.5",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"

--- a/package.json
+++ b/package.json
@@ -27,14 +27,15 @@
   "license": "MIT",
   "dependencies": {
     "bclient": "~0.0.2",
+    "bcoin": "bcoin-org/bcoin#e093b2b",
     "bcrypto": "~0.2.0",
     "bdb": "~0.1.0",
+    "bevent": "0.0.2",
     "blgr": "~0.0.2",
     "bmutex": "~0.0.2",
     "bstring": "~0.0.2",
     "bufio": "~0.1.0",
     "bval": "~0.0.2",
-    "bcoin": "bcoin-org/bcoin#e093b2b",
     "bweb": "~0.0.2"
   },
   "devDependencies": {

--- a/test/db-test.js
+++ b/test/db-test.js
@@ -6,6 +6,7 @@
 const assert = require('./util/assert');
 const MultisigDB = require('../lib/multisigdb');
 const layout = require('../lib/layout').msdb;
+const WalletNullClient = require('../lib/walletnullclient');
 
 /*
  * Most test cases are handled by http-test
@@ -13,18 +14,16 @@ const layout = require('../lib/layout').msdb;
 
 describe('Multisig Database', function () {
   it('should open database', async () => {
-    const msdb = new MultisigDB({
-      client: {}
-    });
+    const client = new WalletNullClient();
+    const msdb = new MultisigDB({ client });
 
     await msdb.open();
     await msdb.close();
   });
 
   it('should create version entry', async () => {
-    const msdb = new MultisigDB({
-      client: {}
-    });
+    const client = new WalletNullClient();
+    const msdb = new MultisigDB({ client });
     const db = msdb.db;
 
     await msdb.open();

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -49,14 +49,14 @@ const walletNode = new wallet.Node({
   nodeApiKey: options.apiKey,
   adminToken: ADMIN_TOKEN,
 
-  //logLevel: 'debug',
+  // logLevel: 'debug',
 
   plugins: [require('../lib/bmultisig')]
 });
 
 const wdb = walletNode.wdb;
 
-walletNode.on('error', err => console.log(err));
+// walletNode.on('error', err => console.error(err));
 
 const TEST_XPUB_PATH = 'm/44\'/0\'/0\'';
 

--- a/test/integration/wallet-test.js
+++ b/test/integration/wallet-test.js
@@ -114,8 +114,7 @@ describe('HTTP', function () {
 
     let err;
     try {
-      const res = await msclient.getInfo('test');
-      console.log(res);
+      await msclient.getInfo('test');
     } catch (e) {
       err = e;
     }

--- a/test/proposals-test.js
+++ b/test/proposals-test.js
@@ -311,7 +311,7 @@ describe('MultisigProposals', function () {
     assert.instanceOf(proposal2, Proposal);
   });
 
-  it('should fail rejecting rejected proposal', async () => {
+  it('should fail rejecting rejected proposal twice', async () => {
     await utils.fundWalletBlock(wdb, mswallet, 1);
 
     const txoptions = getTXOptions(1);
@@ -330,7 +330,7 @@ describe('MultisigProposals', function () {
     assert.strictEqual(err.message, 'Can not reject non pending proposal.');
   });
 
-  it('should fail approving proposal', async () => {
+  it('should fail approving proposal twice', async () => {
     await utils.fundWalletBlock(wdb, mswallet, 1);
     await utils.fundWalletBlock(wdb, mswallet, 1);
 
@@ -373,7 +373,7 @@ describe('MultisigProposals', function () {
     );
   });
 
-  it('should approve signed proposal.', async () => {
+  it('should approve signed proposal', async () => {
     await utils.fundWalletBlock(wdb, mswallet, 1);
 
     const txoptions = getTXOptions(1);
@@ -418,6 +418,27 @@ describe('MultisigProposals', function () {
 
     await approve(priv1, cosigner1);
     await approve(priv2, cosigner2);
+  });
+
+  it('should recover coins on rejection', async () => {
+    await utils.fundWalletBlock(wdb, mswallet, 1);
+
+    const proposal = await mswallet.createProposal(
+      'proposal',
+      cosigner1,
+      getTXOptions(1)
+    );
+
+    assert.instanceOf(proposal, Proposal);
+
+    const coins = await mswallet.getProposalCoins('proposal');
+    const rejected = await mswallet.rejectProposal('proposal', cosigner1);
+
+    const coin = coins[0];
+    const pidByOutpoint = await mswallet.getPIDByOutpoint(coin);
+
+    assert.strictEqual(rejected.status, Proposal.status.REJECTED);
+    assert.strictEqual(pidByOutpoint, -1);
   });
 });
 

--- a/test/proposals-test.js
+++ b/test/proposals-test.js
@@ -6,6 +6,7 @@
 const assert = require('./util/assert');
 const utils = require('./util/wallet');
 
+// const Logger = require('blgr');
 const bcoin = require('bcoin');
 const {Script, KeyRing, MTX, Amount, hd} = bcoin;
 const WalletDB = bcoin.wallet.WalletDB;
@@ -36,14 +37,26 @@ describe('MultisigProposals', function () {
   let cosigner1, cosigner2;
 
   beforeEach(async () => {
-    wdb = new WalletDB();
+    // const logger = new Logger({
+    //   level: 'debug',
+    //   console: true
+    // });
 
-    const wdbClient = new WalletNodeClient({});
-    wdbClient.wdb = wdb;
+    // await logger.open();
+
+    wdb = new WalletDB({ });
+
+    const wdbClient = new WalletNodeClient({ wdb });
 
     msdb = new MultisigDB({
+      // logger,
       client: wdbClient
     });
+
+    wdb.on('error', () => {});
+    msdb.on('error', () => {});
+
+    msdb.init();
 
     await wdb.open();
     await msdb.open();
@@ -224,10 +237,6 @@ describe('MultisigProposals', function () {
 
     assert.strictEqual(proposal.id, pid);
     assert(proposal.equals(proposal2));
-  });
-
-  // TODO:
-  it('should reject proposal with reorged coins', async () => {
   });
 
   it('should get proposal', async () => {
@@ -439,6 +448,101 @@ describe('MultisigProposals', function () {
 
     assert.strictEqual(rejected.status, Proposal.status.REJECTED);
     assert.strictEqual(pidByOutpoint, -1);
+  });
+
+  it('should reject proposal on mempool double spend', async () => {
+    const txoptions = getTXOptions(1);
+
+    const amount = Amount.fromBTC(1).toValue();
+    const account = await mswallet.getAccount();
+    const mtx = utils.createFundTX(account.receiveAddress(), amount);
+
+    await wdb.addTX(mtx.toTX());
+
+    await mswallet.createProposal(
+      'proposal-1',
+      cosigner1,
+      txoptions
+    );
+
+    const dstx = utils.getDoubleSpendTransaction(mtx);
+
+    await wdb.addTX(dstx.toTX());
+
+    const checkProposal = await mswallet.getProposal('proposal-1');
+
+    assert.instanceOf(checkProposal, Proposal);
+    assert.strictEqual(checkProposal.status, Proposal.status.DBLSPEND);
+  });
+
+  it('should reject proposal on coin spend', async () => {
+    const txoptions = getTXOptions(1);
+    await utils.fundWalletBlock(wdb, mswallet, 1);
+
+    const proposal = await mswallet.createProposal(
+      'proposal-1',
+      cosigner1,
+      txoptions
+    );
+
+    const mtx = await mswallet.getProposalMTX('proposal-1');
+    const paths = await mswallet.getInputPaths(mtx);
+
+    const sign = async (priv) => {
+      mtx.inputs.forEach((input, i) => {
+        const path = paths[i];
+
+        // derive correct priv key
+        const _priv = priv.derive(path.branch).derive(path.index);
+
+        // derive pubkeys
+        const p1 = xpub1.derive(path.branch).derive(path.index);
+        const p2 = xpub2.derive(path.branch).derive(path.index);
+
+        const ring = KeyRing.fromPrivate(_priv.privateKey);
+
+        ring.script = Script.fromMultisig(
+          proposal.m,
+          proposal.n,
+          [p1.publicKey, p2.publicKey]
+        );
+
+        const signed = mtx.sign(ring);
+
+        assert.strictEqual(signed, 1);
+      });
+    };
+
+    sign(priv1);
+    sign(priv2);
+
+    await wdb.addBlock(utils.nextBlock(wdb), [mtx.toTX()]);
+
+    const checkProposal = await mswallet.getProposal('proposal-1');
+
+    assert.instanceOf(checkProposal, Proposal);
+    assert.strictEqual(checkProposal.status, Proposal.status.DBLSPEND);
+  });
+
+  it('should reject proposal on reorg double spend', async () => {
+    const txoptions = getTXOptions(1);
+    const mtx = await utils.fundWalletBlock(wdb, mswallet, 1);
+
+    const proposal1 = await mswallet.createProposal(
+      'proposal-1',
+      cosigner1,
+      txoptions
+    );
+
+    assert.instanceOf(proposal1, Proposal);
+
+    await utils.removeBlock(wdb);
+    await utils.doubleSpendTransaction(wdb, mtx.toTX());
+
+    const checkProposal = await mswallet.getProposal('proposal-1');
+
+    assert.instanceOf(checkProposal, Proposal);
+    assert.strictEqual(checkProposal.status, Proposal.status.DBLSPEND);
   });
 });
 

--- a/test/proposals-test.js
+++ b/test/proposals-test.js
@@ -206,6 +206,26 @@ describe('MultisigProposals', function () {
     assert.strictEqual(err.message, message, 'Incorrect error message.');
   });
 
+  it('should get proposal by coin', async () => {
+    await utils.fundWalletBlock(wdb, mswallet, 1);
+
+    const coins = await wallet.getCoins();
+
+    const proposal = await mswallet.createProposal(
+      'proposal',
+      cosigner1,
+      getTXOptions(1)
+    );
+
+    assert.instanceOf(proposal, Proposal);
+
+    const pid = await mswallet.getPIDByOutpoint(coins[0]);
+    const proposal2 = await mswallet.getProposalByOutpoint(coins[0]);
+
+    assert.strictEqual(proposal.id, pid);
+    assert(proposal.equals(proposal2));
+  });
+
   // TODO:
   it('should reject proposal with reorged coins', async () => {
   });

--- a/test/util/wallet.js
+++ b/test/util/wallet.js
@@ -94,7 +94,7 @@ exports.getDoubleSpendTransaction = (tx) => {
 };
 
 // Spend transaction
-exports.spendTransaction = async (wdb, tx) => {
+exports.doubleSpendTransaction = async (wdb, tx) => {
   const mtx = exports.getDoubleSpendTransaction(tx);
 
   await wdb.addBlock(exports.nextBlock(wdb), [mtx.toTX()]);

--- a/test/util/wallet.js
+++ b/test/util/wallet.js
@@ -3,7 +3,7 @@
 const bcoin = require('bcoin');
 const hash256 = require('bcrypto/lib/hash256');
 const random = require('bcrypto/lib/random');
-const {Amount, MTX, Input, Outpoint} = bcoin;
+const {Script, Amount, MTX, Input, Outpoint} = bcoin;
 
 exports.curBlock = (wdb) => {
   return exports.fakeBlock(wdb.state.height);
@@ -38,6 +38,11 @@ exports.dummyInput = () => {
   return Input.fromOutpoint(new Outpoint(hash, 0));
 };
 
+exports.dummyCoinbase = () => {
+  const hash = Buffer.alloc(32, 0).toString('hex');
+  return Input.fromOutpoint(new Outpoint(hash, 0xffffffff));
+};
+
 /**
  * @param {bcoin#Address} address
  * @param {Number} value
@@ -59,6 +64,7 @@ exports.createFundTX = (address, value) => {
  * @param {WalletDB} wdb
  * @param {MultisigWallet} mswallet
  * @param {Number} amount - number in BTC
+ * @returns {MTX}
  */
 
 exports.fundWalletBlock = async (wdb, mswallet, amount) => {
@@ -74,6 +80,52 @@ exports.fundAddressBlock = async (wdb, address, amount) => {
   const mtx = exports.createFundTX(address, amount);
 
   await wdb.addBlock(exports.nextBlock(wdb), [mtx.toTX()]);
+
+  return mtx;
+};
+
+// Spend transaction
+exports.spendTransaction = async (wdb, tx) => {
+  const mtx = MTX.fromTX(tx);
+
+  mtx.outputs = [];
+  mtx.addOutput(Script.fromString(''));
+
+  await wdb.addBlock(exports.nextBlock(wdb), [mtx.toTX()]);
+};
+
+// Coinbase fund
+exports.createCoinbaseFundTX = (address, value) => {
+  const mtx = new MTX();
+  mtx.addInput(exports.dummyCoinbase());
+  mtx.addOutput(address, value);
+
+  return mtx;
+};
+
+exports.fundWalletBlockCB = async (wdb, mswallet, amount) => {
+  const account = await mswallet.getAccount();
+  const address = await account.receiveAddress();
+
+  return exports.fundAddressBlockCB(wdb, address, amount);
+};
+
+exports.fundAddressBlockCB = async (wdb, address, amount) => {
+  amount = Amount.fromBTC(amount).toValue();
+
+  const mtx = exports.createCoinbaseFundTX(address, amount);
+
+  await wdb.addBlock(exports.nextBlock(wdb), [mtx.toTX()]);
+};
+
+exports.addBlock = async (wdb) => {
+  await wdb.addBlock(exports.nextBlock(wdb), []);
+};
+
+exports.removeBlock = async (wdb) => {
+  const block = exports.curBlock(wdb);
+
+  await wdb.removeBlock(block);
 };
 
 /*

--- a/test/util/wallet.js
+++ b/test/util/wallet.js
@@ -84,12 +84,18 @@ exports.fundAddressBlock = async (wdb, address, amount) => {
   return mtx;
 };
 
-// Spend transaction
-exports.spendTransaction = async (wdb, tx) => {
+exports.getDoubleSpendTransaction = (tx) => {
   const mtx = MTX.fromTX(tx);
 
   mtx.outputs = [];
   mtx.addOutput(Script.fromString(''));
+
+  return mtx;
+};
+
+// Spend transaction
+exports.spendTransaction = async (wdb, tx) => {
+  const mtx = exports.getDoubleSpendTransaction(tx);
 
   await wdb.addBlock(exports.nextBlock(wdb), [mtx.toTX()]);
 };

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -46,8 +46,9 @@ describe('MultisigWallet', function () {
   beforeEach(async () => {
     wdb = new WalletDB();
 
-    const wdbClient = new WalletNodeClient({});
-    wdbClient.wdb = wdb;
+    const wdbClient = new WalletNodeClient({
+      wdb
+    });
 
     msdb = new MultisigDB({
       client: wdbClient


### PR DESCRIPTION
Proposals will keep track of the coins updates which happen on `tx`, `confirmed`, `unconfirmed`, `remove tx` events and will reject proposals (and free locked coins) accordingly.

* Proposal: add equals method.
* WalletClient: listen for events
* WalletNullClient - mostly for testing
* Watch for walletdb events
* Save Outpoint -> PID mapping in DB.
* AddTX - Handle double spend in mempool or unseen transaction in block.
* confirmedTX - Handle double spend if we got here somehow.
* removeTX - Handle reorg double spend or mempool double spend of coins
* coin spend - Addtx/confirmed will also handle case when transaction was broadcasted from different node (Basically same as double spend)
* Test double spend scenarios.
* Cleanup some tests.