### PR TITLE
Approve proposal with signatures instead of TX.

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -114,7 +114,7 @@ class MultisigAccount {
   }
 
   inspect() {
-    return {};
+    return this.toJSON();
   }
 
   toJSON(balance) {

--- a/lib/bmultisig-browser.js
+++ b/lib/bmultisig-browser.js
@@ -25,5 +25,6 @@ bmultisig.Client = require('./client');
 // primitives
 bmultisig.Cosigner = require('./primitives/cosigner');
 bmultisig.Proposal = require('./primitives/proposal');
+bmultisig.MultisigMTX = require('./primitives/mtx');
 
 bmultisig.pkg = require('./pkg');

--- a/lib/bmultisig.js
+++ b/lib/bmultisig.js
@@ -47,6 +47,7 @@ bmultisig.define('Client', './client');
 // primitives
 bmultisig.define('Cosigner', './primitives/cosigner');
 bmultisig.define('Proposal', './primitives/proposal');
+bmultisig.define('MultisigMTX', './primitives/mtx');
 
 bmultisig.define('MultisigDB', './multisigdb');
 bmultisig.define('ProposalDB', './proposaldb');

--- a/lib/client.js
+++ b/lib/client.js
@@ -454,12 +454,12 @@ class MultisigClient extends WalletClient {
    * Approve proposal
    * @param {String} id
    * @param {String} name
-   * @param {Buffer} tx - raw signed tx
+   * @param {Buffer[]} signatures
    * @returns {Promise<Proposal>}
    */
 
-  approveProposal(id, name, tx) {
-    return this.post(`/${id}/proposal/${name}/approve`, { tx });
+  approveProposal(id, name, signatures) {
+    return this.post(`/${id}/proposal/${name}/approve`, { signatures });
   }
 
   /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -472,6 +472,17 @@ class MultisigClient extends WalletClient {
   rejectProposal(id, name) {
     return this.post(`/${id}/proposal/${name}/reject`);
   }
+
+  /**
+   * Send proposal tx
+   * @param {String} id
+   * @param {String} name
+   * @returns {Promise<TX>}
+   */
+
+  sendProposal(id, name) {
+    return this.post(`/${id}/proposal/${name}/send`);
+  }
 }
 
 /**
@@ -769,6 +780,16 @@ class MultisigWallet extends EventEmitter {
 
   rejectProposal(name) {
     return this.client.rejectProposal(this.id, name);
+  }
+
+  /**
+   * Send proposal tx
+   * @param {String} name
+   * @returns {Promise<TX>}
+   */
+
+  sendProposal(id, name) {
+    return this.client.sendProposal(this.id, name);
   }
 }
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -8,7 +8,7 @@
 
 const assert = require('bsert');
 const bcoin = require('bcoin');
-const {TX, Script, Address, Network} = bcoin;
+const {Script, Address, Network} = bcoin;
 const HDPublicKey = bcoin.hd.HDPublicKey;
 const Validator = require('bval');
 const Logger = require('blgr');
@@ -302,13 +302,15 @@ class MultisigHTTP extends Server {
       };
 
       const key = valid.str('xpub');
+      const xpub = HDPublicKey.fromBase58(key, this.network);
+
       const cosigner = Cosigner.fromOptions({
         name: valid.str('cosignerName'),
-        path: valid.str('cosignerPath')
+        path: valid.str('cosignerPath'),
+        key: xpub
       });
 
-      const xpub = HDPublicKey.fromBase58(key, this.network);
-      const wallet = await this.msdb.create(walletOptions, cosigner, xpub);
+      const wallet = await this.msdb.create(walletOptions, cosigner);
 
       res.json(200, wallet.toJSON(0));
     });
@@ -336,12 +338,14 @@ class MultisigHTTP extends Server {
      */
     this.post('/:id/join', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const joinKey = Buffer.from(valid.str('joinKey'), 'hex');
+      const joinKey = valid.buf('joinKey');
       const b58 = valid.str('xpub');
+      const xpub = HDPublicKey.fromBase58(b58, this.network);
 
       const cosigner = Cosigner.fromOptions({
         name: valid.str('cosignerName'),
-        path: valid.str('cosignerPath')
+        path: valid.str('cosignerPath'),
+        key: xpub
       });
 
       const validKey = req.mswallet.verifyJoinKey(joinKey);
@@ -351,7 +355,6 @@ class MultisigHTTP extends Server {
 
       enforce(b58, 'XPUB is required');
 
-      const xpub = HDPublicKey.fromBase58(b58, this.network);
       const joined = await req.mswallet.join(cosigner, xpub);
       const cosignerIndex = joined.cosigners.length - 1;
 
@@ -387,7 +390,8 @@ class MultisigHTTP extends Server {
     });
 
     /*
-     * Get list of proposals
+     * Get list of proposals.
+     * TODO: Add limits.
      */
     this.get('/:id/proposal', async (req, res) => {
       const valid = Validator.fromRequest(req);
@@ -407,7 +411,7 @@ class MultisigHTTP extends Server {
     });
 
     /*
-     * Create proposal
+     * Create proposal.
      */
     this.put('/:id/proposal/:name', async (req, res) => {
       const valid = Validator.fromRequest(req);
@@ -420,12 +424,11 @@ class MultisigHTTP extends Server {
         options
       );
 
-      if (!proposal) {
-        res.json(400);
-        return;
-      }
+      const tx = await req.mswallet.getProposalMTX(proposal.id);
 
-      res.json(200, proposalCosignerJSON(proposal, req.mswallet));
+      enforce(proposal, 'Could not create proposal.');
+
+      res.json(200, proposalCosignerJSON(proposal, req.mswallet, tx));
     });
 
     /*
@@ -658,12 +661,15 @@ class MultisigHTTPOptions {
 /**
  * Update proposal with cosigner info
  * returns JSON
+ * TODO: move this to cosigner/add fields.
  * @param {Proposal} proposal
+ * @param {MultisigWallet} mswallet
+ * @param {TX} tx
  * @returns {Object}
  */
 
-function proposalCosignerJSON(proposal, mswallet) {
-  const pobject = proposal.toJSON();
+function proposalCosignerJSON(proposal, mswallet, tx) {
+  const pobject = proposal.toJSON(tx);
 
   pobject.author = mswallet.cosigners[pobject.author].toJSON();
   pobject.approvals = pobject.approvals.map((i) => {

--- a/lib/http.js
+++ b/lib/http.js
@@ -452,14 +452,13 @@ class MultisigHTTP extends Server {
 
     /*
      * Get proposal mtx
+     * TODO: Add option for returning previous transactions.
      */
     this.get('/:id/proposal/:name/tx', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
 
       const getPaths = valid.bool('paths', false);
-      // const getTXs = valid.bool('tx', false);
-      // const getRings = valid.bool('rings', false);
       const getScripts = valid.bool('scripts', false);
 
       let paths, txs, rings, scripts;
@@ -473,9 +472,6 @@ class MultisigHTTP extends Server {
 
       if (getPaths)
         paths = await req.mswallet.getInputPaths(mtx);
-
-      // if (getRings)
-      //   rings = await req.mswallet.deriveInputs(mtx, paths);
 
       if (getScripts && rings)
         scripts = rings.map(r => r.script);
@@ -502,12 +498,6 @@ class MultisigHTTP extends Server {
           };
         }) : null,
 
-        // rings: rings ? rings.map((r) => {
-        //   // TODO: wrap in custom keyring
-        //   r.publicKey = '';
-        //   return r.toJSON(this.network);
-        // }) : null,
-
         scripts: scripts ? scripts.map(s => s.toRaw('hex')) : null
       });
     });
@@ -518,8 +508,16 @@ class MultisigHTTP extends Server {
     this.post('/:id/proposal/:name/approve', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
-      const hexSigs = valid.array('signatures');
-      const sigs = hexSigs.map(sig => Buffer.from(sig, 'hex'));
+      const hexSigs = valid.array('signatures', []);
+
+      enforce(hexSigs.length, 'Could not find signatures');
+
+      const sigs = hexSigs.map((sig) => {
+        if (!sig)
+          return null;
+
+        return Buffer.from(sig, 'hex');
+      });
 
       enforce(sigs && sigs.length > 0, 'Signatures not found.');
 
@@ -555,6 +553,23 @@ class MultisigHTTP extends Server {
       }
 
       res.json(200, proposalCosignerJSON(proposal, req.mswallet));
+    });
+
+    /*
+     * Send proposal tx
+     */
+    this.post('/:id/proposal/:name/send', async (req, res) => {
+      const valid = Validator.fromRequest(req);
+      const name = valid.str('name');
+
+      const tx = await req.mswallet.sendProposal(name);
+
+      if (!tx) {
+        res.json(404);
+        return;
+      }
+
+      res.json(200, tx.toJSON());
     });
   }
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -217,9 +217,10 @@ class MultisigHTTP extends Server {
    */
 
   initRouter() {
-    if (!this.options.noAuth) {
+    if (this.options.cors)
       this.use(this.cors());
 
+    if (!this.options.noAuth) {
       this.use(this.basicAuth({
         hash: sha256.digest,
         password: this.options.apiKey,
@@ -573,6 +574,7 @@ class MultisigHTTPOptions {
     this.serviceHash = this.apiHash;
     this.noAuth = false;
     this.walletAuth = false;
+    this.cors = false;
 
     this.fromOptions(options);
   }
@@ -640,6 +642,11 @@ class MultisigHTTPOptions {
     if (options.walletAuth != null) {
       assert(typeof options.walletAuth === 'boolean');
       this.walletAuth = options.walletAuth;
+    }
+
+    if (options.cors != null) {
+      assert(typeof options.cors === 'boolean');
+      this.cors = options.cors;
     }
   }
 }

--- a/lib/http.js
+++ b/lib/http.js
@@ -340,6 +340,9 @@ class MultisigHTTP extends Server {
       const valid = Validator.fromRequest(req);
       const joinKey = valid.buf('joinKey');
       const b58 = valid.str('xpub');
+
+      enforce(b58, 'XPUB is required');
+
       const xpub = HDPublicKey.fromBase58(b58, this.network);
 
       const cosigner = Cosigner.fromOptions({
@@ -352,8 +355,6 @@ class MultisigHTTP extends Server {
 
       if (!validKey)
         error(403, 'Invalid joinKey');
-
-      enforce(b58, 'XPUB is required');
 
       const joined = await req.mswallet.join(cosigner, xpub);
       const cosignerIndex = joined.cosigners.length - 1;
@@ -418,6 +419,8 @@ class MultisigHTTP extends Server {
       const options = parseTXOptions(req, this.network);
       const name = valid.str('name');
 
+      enforce(req.cosigner, 'Cosigner not found.');
+
       const proposal = await req.mswallet.createProposal(
         name,
         req.cosigner,
@@ -454,7 +457,7 @@ class MultisigHTTP extends Server {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
 
-      const getPaths = valid.bool('path', false);
+      const getPaths = valid.bool('paths', false);
       // const getTXs = valid.bool('tx', false);
       // const getRings = valid.bool('rings', false);
       const getScripts = valid.bool('scripts', false);

--- a/lib/http.js
+++ b/lib/http.js
@@ -515,14 +515,15 @@ class MultisigHTTP extends Server {
     this.post('/:id/proposal/:name/approve', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const name = valid.str('name');
-      const rawtx = valid.buf('tx');
+      const hexSigs = valid.array('signatures');
+      const sigs = hexSigs.map(sig => Buffer.from(sig, 'hex'));
 
-      const tx = TX.fromRaw(rawtx);
+      enforce(sigs && sigs.length > 0, 'Signatures not found.');
 
       const proposal = await req.mswallet.approveProposal(
         name,
         req.cosigner,
-        tx
+        sigs
       );
 
       if (!proposal) {

--- a/lib/multisigdb.js
+++ b/lib/multisigdb.js
@@ -194,15 +194,14 @@ class MultisigDB extends EventEmitter {
    * @param {Boolean} options.witness
    * @param {String} options.id
    * @param {Cosigner} cosigner
-   * @param {bcoin#hd#PublicKey} xpub
    * @returns {Promise<MultisigWallet>} multisig wallet info
    */
 
-  async create(options, cosigner, xpub) {
+  async create(options, cosigner) {
     const unlock = await this.writeLock.lock();
 
     try {
-      return await this._create(options, cosigner, xpub);
+      return await this._create(options, cosigner);
     } finally {
       unlock();
     }
@@ -213,17 +212,16 @@ class MultisigDB extends EventEmitter {
    * @async
    * @param {Object} options {@link MultisigDB#create}
    * @param {Cosigner} cosigner
-   * @param {bcoin#hd#PublicKey} xpub
    * @returns {Promise<MultisigWallet>}
    */
 
-  async _create(options, cosigner, xpub) {
+  async _create(options, cosigner) {
     const walletOptions = {
       m: options.m,
       n: options.n,
       witness: options.witness,
       id: options.id,
-      accountKey: xpub,
+      accountKey: cosigner.key,
 
       // TODO: currently watchOnly is the
       // only wallet supported. We can also
@@ -313,11 +311,10 @@ class MultisigDB extends EventEmitter {
    * Cosigner joins wallet
    * @param {Number|String} id
    * @param {Cosigner} options {@link Cosigner#constructor}
-   * @param {bcoin#hd#PublicKey} xpub
    * @returns {Promise<MultisigWallet>}
    */
 
-  async join(id, cosigner, xpub) {
+  async join(id, cosigner) {
     const wid = await this.ensureWID(id);
 
     if (wid === -1)
@@ -327,7 +324,7 @@ class MultisigDB extends EventEmitter {
     const unlock2 = await this.writeLock.lock();
 
     try {
-      return this._join(wid, cosigner, xpub);
+      return this._join(wid, cosigner);
     } finally {
       unlock2();
       unlock1();
@@ -338,11 +335,10 @@ class MultisigDB extends EventEmitter {
    * Join cosigner to wallet
    * @param {Number} wid
    * @param {Cosigner} cosigner
-   * @param {bcoin#hd#PublicKey} xpub
    * @returns {Promise<MultisigWallet>}
    */
 
-  async _join(wid, cosigner, xpub) {
+  async _join(wid, cosigner) {
     const mswallet = await this.getWallet(wid);
 
     if (!mswallet)
@@ -350,7 +346,7 @@ class MultisigDB extends EventEmitter {
 
     const wallet = mswallet.wallet;
 
-    const res = await wallet.addSharedKey(0, xpub);
+    const res = await wallet.addSharedKey(0, cosigner.key);
 
     assert(res, 'Can not add duplicate keys');
 

--- a/lib/primitives/cosigner.js
+++ b/lib/primitives/cosigner.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-const assert = require('assert');
+const assert = require('bsert');
 const bufio = require('bufio');
 const {Struct} = bufio;
 const common = require('bcoin/lib/wallet/common');
@@ -236,6 +236,19 @@ class Cosigner extends Struct {
       && this.path === cosigner.path
       && this.tokenDepth === cosigner.tokenDepth
       && this.token.equals(cosigner.token);
+  }
+
+  /**
+   * Derive pubkey for cosigner
+   * @param {branch} branch
+   * @param {index} index
+   * @returns {Buffer} - Public key
+   */
+
+  deriveKey(branch, index) {
+    assert(this.key);
+
+    return this.key.derive(branch).derive(index);
   }
 
   /**

--- a/lib/primitives/cosigner.js
+++ b/lib/primitives/cosigner.js
@@ -8,8 +8,9 @@
 
 const assert = require('assert');
 const bufio = require('bufio');
-const common = require('bcoin').wallet.common;
 const {Struct} = bufio;
+const common = require('bcoin/lib/wallet/common');
+const HDPublicKey = require('bcoin/lib/hd/public');
 
 const NULL_TOKEN = Buffer.alloc(32);
 
@@ -42,6 +43,7 @@ class Cosigner extends Struct {
     this.path = '';
     this.tokenDepth = 0;
     this.token = NULL_TOKEN;
+    this.key = null;
 
     if (options)
       this.fromOptions(options);
@@ -58,7 +60,12 @@ class Cosigner extends Struct {
       return this;
 
     assert(common.isName(options.name), 'Bad cosigner name');
+    assert(HDPublicKey.isHDPublicKey(options.key),
+      'Account key is required.'
+    );
+
     this.name = options.name;
+    this.key = options.key;
 
     if (options.id != null) {
       assert(isU8(options.id), 'ID must be uint8.');
@@ -160,17 +167,19 @@ class Cosigner extends Struct {
     size += this.name.length;
     size += 1;
     size += this.path.length;
+    size += this.key.getSize();
 
     return size;
   }
 
   /**
    * Serialize to reader
-   * @param {bufio#BufferWriter}
+   * @param {bufio#BufferWriter} bw
+   * @param {Network} network
    * @returns {BufferWriter}
    */
 
-  write(bw) {
+  write(bw, network) {
     bw.writeU8(this.id);
     bw.writeU32(this.tokenDepth);
     bw.writeBytes(this.token);
@@ -179,24 +188,34 @@ class Cosigner extends Struct {
     bw.writeU8(this.path.length);
     bw.writeBytes(Buffer.from(this.path, 'utf8'));
 
+    // this.key.toWriter(bw, network) -- will cause hash256 digest
+    // to be calculated for whole cosigner buffer.
+    bw.writeBytes(this.key.toRaw(network));
+
     return bw;
   }
 
   /**
    * Deserialize from reader
    * @param {bufio#BufferReader} br
+   * @param {Network} network
    * @returns {Cosigner}
    */
 
-  read(br) {
+  read(br, network) {
     this.id = br.readU8();
     this.tokenDepth = br.readU32();
     this.token = br.readBytes(32);
 
     const nameSize = br.readU8();
     this.name = br.readBytes(nameSize).toString('utf8');
+
     const pathSize = br.readU8();
     this.path = br.readBytes(pathSize).toString('utf8');
+
+    // HDPublicKey size is 82.
+    const key = br.readBytes(82);
+    this.key = HDPublicKey.fromRaw(key, network);
 
     return this;
   }
@@ -217,6 +236,16 @@ class Cosigner extends Struct {
       && this.path === cosigner.path
       && this.tokenDepth === cosigner.tokenDepth
       && this.token.equals(cosigner.token);
+  }
+
+  /**
+   * Test whether an object is a Cosigner.
+   * @param {Object} obj
+   * @returns {Boolean}
+   */
+
+  static isCosigner(obj) {
+    return obj instanceof Cosigner;
   }
 }
 

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -1,0 +1,288 @@
+/*!
+ * mtx.js - MTX extended for multisig
+ * Copyright (c) 2018, The Bcoin Developers (MIT License).
+ * https://github.com/bcoin-org/bmultisig
+ */
+
+'use strict';
+
+const assert = require('bsert');
+const {enforce} = assert;
+const MTX = require('bcoin/lib/primitives/mtx');
+const Coin = require('bcoin/lib/primitives/coin');
+const Script = require('bcoin/lib/script/script');
+
+/**
+ * Multisig MTX
+ * TODO: throw correct errors.
+ */
+
+class MultisigMTX extends MTX {
+  constructor(options) {
+    super(options);
+  }
+
+  /**
+   * Check if coin we are spending
+   * is witness.
+   * TODO: Belongs to Coin.
+   * @param {Coin} coin
+   * @param {KeyRing} ring
+   * @returns {Boolean} - true if it's witness program,
+   * false if it is normal or ring does not own coin.
+   */
+
+  isWitnessCoin(coin, ring) {
+    assert(ring.ownOutput(coin), 'Coin does not belong to the ring.');
+    const prev = coin.script;
+
+    if (prev.isProgram())
+      return true;
+
+    const sh = prev.getScripthash();
+
+    if (sh) {
+      const redeem = ring.getRedeem(sh);
+
+      // should not happen
+      if (!redeem)
+        throw new Error('redeem script not found.');
+
+      if (redeem.isProgram())
+        return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Get script to sign.
+   * TODO: Belongs to Coin.
+   * @param {Coin} coin
+   * @param {KeyRing} ring
+   * @returns {Script?}
+   */
+
+  getPrevScript(coin, ring) {
+    const prev = coin.script;
+
+    const sh = prev.getScripthash();
+
+    if (sh) {
+      const redeem = ring.getRedeem(sh);
+
+      if (!redeem)
+        return null;
+
+      // Regular P2SH.
+      if (!redeem.isProgram())
+        return redeem.clone();
+
+      // nested P2WSH
+      const wsh = redeem.getWitnessScripthash();
+
+      if (wsh) {
+        const wredeem = ring.getRedeem(wsh);
+
+        if (!wredeem)
+          return null;
+
+        return wredeem.clone();
+      }
+
+      // nested P2WPKH
+      const wpkh = redeem.getWitnessPubkeyhash();
+
+      if (wpkh)
+        return Script.fromPubkeyhash(wpkh);
+
+      // Unknown witness program.
+      return null;
+    }
+
+    // normal output.
+    if (!prev.isProgram())
+      return prev.clone();
+
+    // P2WSH
+    const wsh = prev.getWitnessScripthash();
+
+    if (wsh) {
+      const wredeem = ring.getRedeem(wsh);
+
+      if (!wredeem)
+        return null;
+
+      return wredeem.clone();
+    }
+
+    // P2WPKH
+    const wpkh = prev.getWitnessPubkeyhash();
+
+    if (wpkh)
+      return Script.fromPubkeyhash(wpkh);
+
+    return null;
+  }
+
+  /**
+   * Verify signature without modifying transaction
+   * TODO: verifySignature
+   * @param {Number} index - index of input being verified.
+   * @param {Coin} coin
+   * @param {KeyRing} ring
+   * @param {Buffer} signature
+   * @param {SighashType} type
+   * @return {Boolean}
+   */
+
+  checkSignature(index, coin, ring, signature) {
+    const input = this.inputs[index];
+    const value = coin.value;
+
+    assert(input, 'Input does not exist.');
+    enforce(Coin.isCoin(coin), 'coin', 'Coin');
+    enforce(Buffer.isBuffer(signature), 'signature', 'buffer');
+
+    const prev = this.getPrevScript(coin, ring);
+    const version = this.isWitnessCoin(coin, ring) ? 1 : 0;
+    const key = ring.publicKey;
+
+    return this.checksig(index, prev, value, signature, key, version);
+  }
+
+  /**
+   * Sign and return signature
+   * @param {Number} index - index of input being signed.
+   * @param {Coin|Output} coin
+   * @param {KeyRing} ring
+   * @param {SighashType} type
+   * @returns {Buffer}
+   */
+
+  getInputSignature(index, coin, ring, type) {
+    const input = this.inputs[index];
+
+    assert(input, 'Input does not exist.');
+    assert(coin, 'Input does not exist.');
+
+    const key = ring.privateKey;
+    const value = coin.value;
+    const version = this.isWitnessCoin(coin, ring) ? 1 : 0;
+    const prev = this.getPrevScript(coin, ring);
+
+    return this.signature(index, prev, value, key, type, version);
+  }
+
+  /**
+   * Apply signature without validating signature
+   * @param {Number} index - index of input being signed.
+   * @param {Coin|Output} coin
+   * @param {KeyRing} ring
+   * @param {Buffer} signature
+   * @param {Boolean} valid - verify signature
+   * @returns {Boolean} whether the signature was applied.
+   */
+
+  applySignature(index, coin, ring, signature, valid) {
+    const input = this.inputs[index];
+    const key = ring.publicKey;
+
+    assert(input, 'Input does not exist.');
+    assert(coin, 'No coin passed.');
+    assert(signature, 'No signature passed.');
+
+    // Get the previous output's script
+    const value = coin.value;
+    let prev = coin.script;
+    let vector = input.script;
+    let version = 0;
+    let redeem = false;
+
+    // Grab regular p2sh redeem script.
+    if (prev.isScripthash()) {
+      prev = input.script.getRedeem();
+      if (!prev)
+        throw new Error('Input has not been templated.');
+      redeem = true;
+    }
+
+    // If the output script is a witness program,
+    // we have to switch the vector to the witness
+    // and potentially alter the length. Note that
+    // witnesses are stack items, so the `dummy`
+    // _has_ to be an empty buffer (what OP_0
+    // pushes onto the stack).
+    if (prev.isWitnessScripthash()) {
+      prev = input.witness.getRedeem();
+      if (!prev)
+        throw new Error('Input has not been templated.');
+      vector = input.witness;
+      redeem = true;
+      version = 1;
+    } else {
+      const wpkh = prev.getWitnessPubkeyhash();
+      if (wpkh) {
+        prev = Script.fromPubkeyhash(wpkh);
+        vector = input.witness;
+        redeem = false;
+        version = 1;
+      }
+    }
+
+    if (valid && !this.checksig(index, prev, value, signature, key, version))
+      return false;
+
+    if (redeem) {
+      const stack = vector.toStack();
+      const redeem = stack.pop();
+
+      const result = this.signVector(prev, stack, signature, ring);
+
+      if (!result)
+        return false;
+
+      result.push(redeem);
+
+      vector.fromStack(result);
+
+      return true;
+    }
+
+    const stack = vector.toStack();
+    const result = this.signVector(prev, stack, signature, ring);
+
+    if (!result)
+      return false;
+
+    vector.fromStack(result);
+
+    return true;
+  }
+
+  /**
+   * Instantiate MultisigMTX from MTX.
+   * @param {MTX} mtx
+   * @returns {MultisigMTX}
+   */
+
+  static fromMTX(mtx) {
+    return new this().inject(mtx);
+  }
+
+  /**
+   * Test whether an object is a MultisigMTX.
+   * @param {Object} obj
+   * @returns {Boolean}
+   */
+
+  static isMultisigMTX(obj) {
+    return obj instanceof MultisigMTX;
+  }
+}
+
+/*
+ * Expose
+ */
+
+module.exports = MultisigMTX;

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -11,6 +11,7 @@ const {enforce} = assert;
 const MTX = require('bcoin/lib/primitives/mtx');
 const Coin = require('bcoin/lib/primitives/coin');
 const Script = require('bcoin/lib/script/script');
+const Witness = require('bcoin/lib/script/witness');
 
 /**
  * Multisig MTX
@@ -127,6 +128,7 @@ class MultisigMTX extends MTX {
 
   /**
    * Verify signature without modifying transaction
+   * TODO: move to TX
    * TODO: verifySignature
    * @param {Number} index - index of input being verified.
    * @param {Coin} coin
@@ -153,6 +155,8 @@ class MultisigMTX extends MTX {
 
   /**
    * Sign and return signature
+   * TODO: move to TX
+   * TODO: Rename
    * @param {Number} index - index of input being signed.
    * @param {Coin|Output} coin
    * @param {KeyRing} ring
@@ -165,6 +169,7 @@ class MultisigMTX extends MTX {
 
     assert(input, 'Input does not exist.');
     assert(coin, 'Input does not exist.');
+    assert(ring.privateKey, 'No private key available.');
 
     const key = ring.privateKey;
     const value = coin.value;
@@ -172,6 +177,34 @@ class MultisigMTX extends MTX {
     const prev = this.getPrevScript(coin, ring);
 
     return this.signature(index, prev, value, key, type, version);
+  }
+
+  /**
+   * Sign and return input signatures for a ring.
+   * TODO: move to TX
+   * TODO: rename
+   * @param {KeyRing} ring - Keyring
+   * @param {SighashType} type - Sighash type
+   * @returns {Buffer[]}
+   */
+
+  getSignatures(ring, type) {
+    const signatures = new Array(this.inputs.length);
+
+    for (let i = 0; i < this.inputs.length; i++) {
+      const {prevout} = this.inputs[i];
+      const coin = this.view.getOutput(prevout);
+
+      if (!coin)
+        continue;
+
+      if (!ring.ownOutput(coin))
+        continue;
+
+      signatures[i] = this.getInputSignature(i, coin, ring, type);
+    }
+
+    return signatures;
   }
 
   /**
@@ -258,6 +291,58 @@ class MultisigMTX extends MTX {
     vector.fromStack(result);
 
     return true;
+  }
+
+  /**
+   * Apply signatures without validating signatures.
+   * TODO: partially applied?
+   * @param {KeyRing} ring - ring or rings.
+   * @param {Buffer[]} signatures - signatures
+   * @param {Boolean} verify - should we verify applied signature(s)
+   * @return {Boolean} whether the signature was applied.
+   */
+
+  applySignatures(ring, signatures, verify) {
+    for (let i = 0; i < signatures.length; i++) {
+      const signature = signatures[i];
+
+      if (!signature)
+        continue;
+
+      const {prevout} = this.inputs[i];
+      const coin = this.view.getOutput(prevout);
+
+      if (!coin)
+        continue;
+
+      if (!ring.ownOutput(coin))
+        continue;
+
+      // Build script for input
+      if (!this.scriptInput(i, coin, ring))
+        continue;
+
+      if (!this.applySignature(i, coin, ring, signature, verify))
+        return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Empties input scripts and witness
+   */
+
+  emptyInputs() {
+    for (const input of this.inputs) {
+      const {script, witness} = input;
+
+      if (script.length > 0)
+        input.script = new Script();
+
+      if (witness.length > 0)
+        input.witness = new Witness();
+    }
   }
 
   /**

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -183,23 +183,29 @@ class MultisigMTX extends MTX {
    * Sign and return input signatures for a ring.
    * TODO: move to TX
    * TODO: rename
-   * @param {KeyRing} ring - Keyring
+   * @param {KeyRing[]} rings - Keyring
    * @param {SighashType} type - Sighash type
    * @returns {Buffer[]}
    */
 
-  getSignatures(ring, type) {
+  getSignatures(rings, type) {
+    assert(rings.length === this.inputs.length);
     const signatures = new Array(this.inputs.length);
 
-    for (let i = 0; i < this.inputs.length; i++) {
+    for (let i = 0; i < rings.length; i++) {
+      const ring = rings[i];
+
+      if (!ring)
+        continue;
+
       const {prevout} = this.inputs[i];
       const coin = this.view.getOutput(prevout);
 
       if (!coin)
         continue;
 
-      if (!ring.ownOutput(coin))
-        continue;
+      if (!ring.ownOutput)
+        throw new Error('Input does not belong to the key.');
 
       signatures[i] = this.getInputSignature(i, coin, ring, type);
     }
@@ -388,6 +394,10 @@ class MultisigMTX extends MTX {
       if (witness.length > 0)
         input.witness = new Witness();
     }
+  }
+
+  toMTX() {
+    return new MTX().inject(this);
   }
 
   /**

--- a/lib/primitives/mtx.js
+++ b/lib/primitives/mtx.js
@@ -296,27 +296,34 @@ class MultisigMTX extends MTX {
   /**
    * Apply signatures without validating signatures.
    * TODO: partially applied?
-   * @param {KeyRing} ring - ring or rings.
+   * @param {KeyRing[]} ring - ring per signature
    * @param {Buffer[]} signatures - signatures
    * @param {Boolean} verify - should we verify applied signature(s)
    * @return {Boolean} whether the signature was applied.
    */
 
-  applySignatures(ring, signatures, verify) {
+  applySignatures(rings, signatures, verify) {
+    assert(signatures.length === this.inputs.length);
+    assert(signatures.length === rings.length);
+
     for (let i = 0; i < signatures.length; i++) {
       const signature = signatures[i];
+      const ring = rings[i];
 
       if (!signature)
         continue;
+
+      if (!ring)
+        throw new Error('Could not find key.');
 
       const {prevout} = this.inputs[i];
       const coin = this.view.getOutput(prevout);
 
       if (!coin)
-        continue;
+        throw new Error('Could not find coin.');
 
       if (!ring.ownOutput(coin))
-        continue;
+        throw new Error('Coin does not belong to the key.');
 
       // Build script for input
       if (!this.scriptInput(i, coin, ring))
@@ -327,6 +334,44 @@ class MultisigMTX extends MTX {
     }
 
     return true;
+  }
+
+  /**
+   * Check signatures
+   * @param {KeyRing[]} rings - ring per signature
+   * @param {Buffer[]} signatures
+   * @returns {Number} number of valid signatures
+   */
+
+  checkSignatures(rings, signatures) {
+    assert(signatures.length === this.inputs.length);
+
+    let valid = 0;
+
+    for (let i = 0; i < signatures.length; i++) {
+      const signature = signatures[i];
+      const ring = rings[i];
+
+      if (!signature)
+        continue;
+
+      if (!ring)
+        throw new Error('Could not find key.');
+
+      const {prevout} = this.inputs[i];
+      const coin = this.view.getCoin(prevout);
+
+      if (!coin)
+        throw new Error('Could not find coin.');
+
+      if (!ring.ownOutput(coin))
+        throw new Error('Coin does not belong to the key.');
+
+      if (this.checkSignature(i, coin, ring, signature))
+        valid += 1;
+    }
+
+    return valid;
   }
 
   /**

--- a/lib/primitives/proposal.js
+++ b/lib/primitives/proposal.js
@@ -94,7 +94,6 @@ class Proposal extends Struct {
     this.id = 0;
     this.name = '';
     this.author = 0;
-    this.tx = null;
 
     this.status = status.PROGRESS;
 
@@ -125,11 +124,6 @@ class Proposal extends Struct {
     assert(options.m >= 1 && options.m <= options.n,
       'm must be between 1 and n.');
 
-    if (options.tx) {
-      assert(options.tx instanceof TX, 'tx must be instance of TX.');
-      this.tx = options.tx;
-    }
-
     if (options.status != null) {
       assert(status[options.status], 'Incorrect status code.');
       this.status = options.status;
@@ -137,7 +131,6 @@ class Proposal extends Struct {
 
     this.id = options.id;
     this.name = options.name;
-    this.tx = options.tx;
     this.author = options.author;
 
     // TODO: Store signatures for approvals
@@ -157,16 +150,20 @@ class Proposal extends Struct {
 
   /**
    * Get JSON
+   * @param {TX} tx
    * @returns {Object}
    */
 
-  getJSON() {
-    const tx = this.tx ? this.tx.toRaw().toString('hex') : null;
+  getJSON(tx) {
+    let txhex = null;
+
+    if (tx)
+      txhex = tx.toRaw().toString('hex');
 
     return {
       id: this.id,
       name: this.name,
-      tx: tx,
+      tx: txhex,
       author: this.author,
       approvals: this.approvals,
       rejections: this.rejections,
@@ -176,6 +173,22 @@ class Proposal extends Struct {
       statusMessage: statusMessages[this.status]
     };
   }
+
+  /**
+   * Get JSON
+   * @param {TX} tx
+   * @returns {Object}
+   */
+
+  toJSON(tx) {
+    return this.getJSON(tx);
+  }
+
+  /**
+   * Recover proposal from object
+   * @param {Object} json
+   * @returns {Proposal}
+   */
 
   fromJSON(json) {
     assert(json, 'Options are required.');
@@ -195,9 +208,6 @@ class Proposal extends Struct {
     this.n = json.n;
     this.m = json.m;
     this.status = json.statusCode;
-
-    if (json.tx)
-      this.tx = TX.fromRaw(json.tx, 'hex');
 
     this.author = json.author;
 
@@ -559,22 +569,6 @@ class Proposal extends Struct {
   }
 
   /**
-   * Get proposal with TX
-   * @async
-   * @param {Number} pid
-   * @returns {Promise<Proposal>}
-   */
-
-  static async getProposalWithTX(db, pid) {
-    const proposal = await this.getProposal(db, pid);
-    const tx = await this.getTX(db, pid);
-
-    proposal.tx = tx;
-
-    return proposal;
-  }
-
-  /**
    * Get proposal id by coin
    * @param {Outpoint} outpoint
    * @returns {Promise<Number>}
@@ -615,16 +609,6 @@ class Proposal extends Struct {
   static unlockCoin(b, proposal, coin) {
     b.del(layout.c.build(coin.hash, coin.index));
     b.del(layout.C.build(proposal.id, coin.hash, coin.index));
-  }
-
-  /**
-   * Save proposal
-   * @param {Proposal} proposal
-   */
-
-  static saveProposalWithTX(b, proposal) {
-    this.saveProposal(b, proposal);
-    this.saveTX(b, proposal.id, proposal.tx);
   }
 
   /**

--- a/lib/primitives/proposal.js
+++ b/lib/primitives/proposal.js
@@ -106,8 +106,8 @@ class Proposal extends Struct {
     this.m = 1;
     this.n = 2;
 
-    this.approvals = [];
-    this.rejections = [];
+    this.approvals = new ApprovalsMapRecord();
+    this.rejections = new RejectionsSetRecord();
 
     if (options)
       this.fromOptions(options);
@@ -139,11 +139,6 @@ class Proposal extends Struct {
     this.name = options.name;
     this.author = options.author;
 
-    // TODO: Store signatures for approvals
-    // and remove signatures from TX record
-    this.approvals = [];
-    this.rejections = [];
-
     this.m = options.m;
     this.n = options.n;
 
@@ -171,8 +166,8 @@ class Proposal extends Struct {
       name: this.name,
       tx: txhex,
       author: this.author,
-      approvals: this.approvals,
-      rejections: this.rejections,
+      approvals: this.approvals.toJSON(),
+      rejections: this.rejections.toJSON(),
       m: this.m,
       n: this.n,
       statusCode: this.status,
@@ -217,8 +212,9 @@ class Proposal extends Struct {
 
     this.author = json.author;
 
-    this.approvals = json.approvals;
-    this.rejections = json.approvals;
+    // NOTE: Approvals won't store signatures into JSON
+    this.approvals = ApprovalsMapRecord.fromJSON(json.approvals);
+    this.rejections = RejectionsSetRecord.fromJSON(json.rejections);
 
     return this;
   }
@@ -243,10 +239,9 @@ class Proposal extends Struct {
     size += this.name.length;
     size += 1; // status
     size += 1; // author
-    size += 1; // approvals
-    size += this.approvals.length;
-    size += 1; // rejections
-    size += this.rejections.length;
+
+    size += this.approvals.getSize();
+    size += this.rejections.getSize();
 
     return size;
   }
@@ -264,13 +259,8 @@ class Proposal extends Struct {
     bw.writeU8(this.status);
     bw.writeU8(this.author);
 
-    bw.writeU8(this.approvals.length);
-    for (const approval of this.approvals)
-      bw.writeU8(approval);
-
-    bw.writeU8(this.rejections.length);
-    for (const rejection of this.rejections)
-      bw.writeU8(rejection);
+    this.approvals.toWriter(bw);
+    this.rejections.toWriter(bw);
 
     return bw;
   }
@@ -289,13 +279,8 @@ class Proposal extends Struct {
     this.status = br.readU8();
     this.author = br.readU8();
 
-    const approvalsSize = br.readU8();
-    for (let i = 0; i < approvalsSize; i++)
-      this.approvals.push(br.readU8());
-
-    const rejectionsSize = br.readU8();
-    for (let i = 0; i < rejectionsSize; i++)
-      this.rejections.push(br.readU8());
+    this.approvals.fromReader(br);
+    this.rejections.fromReader(br);
 
     return this;
   }
@@ -317,8 +302,8 @@ class Proposal extends Struct {
       && this.n === proposal.n
       && this.author === proposal.author
       && this.status === proposal.status
-      && arrayEquals(this.approvals, proposal.approvals)
-      && arrayEquals(this.rejections, proposal.rejections);
+      && this.approvals.equals(proposal.approvals)
+      && this.rejections.equals(proposal.rejections);
   }
 
   /**
@@ -356,7 +341,7 @@ class Proposal extends Struct {
   updateStatus() {
     assert(this.isPending(), 'Can not update non pending proposal.');
 
-    const rejections = this.rejections.length;
+    const rejections = this.rejections.size;
     const critical = this.n - this.m + 1;
 
     if (rejections >= critical) {
@@ -364,7 +349,7 @@ class Proposal extends Struct {
       return;
     }
 
-    if (this.approvals.length === this.m) {
+    if (this.approvals.size === this.m) {
       this.status = status.APPROVED;
       return;
     }
@@ -381,14 +366,13 @@ class Proposal extends Struct {
     assert(this.isPending(), 'Can not reject non pending proposal.');
 
     // TODO: use map for cosigner status tracking
-    // and use only counter for rejections
-    if (this.approvals.indexOf(cosigner.id) > -1)
+    if (this.approvals.has(cosigner.id))
       throw new Error('Cosigner already approved.');
 
-    if (this.rejections.indexOf(cosigner.id) > -1)
+    if (this.rejections.has(cosigner.id))
       throw new Error('Cosigner already rejected.');
 
-    this.rejections.push(cosigner.id);
+    this.rejections.add(cosigner.id);
     this.updateStatus();
   }
 
@@ -410,23 +394,37 @@ class Proposal extends Struct {
   /**
    * Approve proposal
    * @param {Cosigner} cosigner
+   * @param {SignatureOption[]} signatures
    * @throws {Error}
    */
 
-  approve(cosigner) {
-    assert(cosigner instanceof Cosigner, 'cosigner is not correct.');
+  approve(cosigner, signatures) {
+    enforce(cosigner instanceof Cosigner, 'cosigner', 'Cosigner');
+    enforce(Array.isArray(signatures), 'signatures', 'SignatureOption');
     assert(this.isPending(), 'Can not approve non pending proposal.');
 
-    // TODO: Refactor this part as well (See reject TODO)
-
-    if (this.rejections.indexOf(cosigner.id) > -1)
+    if (this.rejections.has(cosigner.id))
       throw new Error('Cosigner already rejected.');
 
-    if (this.approvals.indexOf(cosigner.id) > -1)
+    if (this.approvals.has(cosigner.id))
       throw new Error('Cosigner already approved.');
 
-    this.approvals.push(cosigner.id);
+    const signaturesRecord = SignaturesRecord.fromSignatures(signatures);
+    this.approvals.set(cosigner.id, signaturesRecord);
     this.updateStatus();
+  }
+
+  /**
+   * Apply all signatures to MTX
+   * @param {Number} id
+   * @param {MultisigMTX} mtx
+   * @param {Ring} ring
+   */
+
+  applySignatures(id, mtx, rings) {
+    const signatures = this.approvals.get(id);
+
+    return mtx.applySignatures(rings, signatures.toSignatures());
   }
 
   /*
@@ -675,31 +673,31 @@ class Proposal extends Struct {
 class RejectionsSetRecord extends Struct {
   /**
    * Initiate rejection set from set
-   * @param {Set} rejections
    */
 
-  constructor(rejections) {
+  constructor() {
     super();
 
     this.rejections = new Set();
-
-    if (rejections)
-      this.fromRejections(rejections);
   }
 
-  fromRejections(rejections) {
-    for (const rejection of rejections.values())
-      this.add(rejection);
+  fromSet(cosigners) {
+    enforce(cosigners instanceof Set, 'cosigners', 'Set');
+
+    for (const id of cosigners.values())
+      this.add(id);
+
+    return this;
   }
 
   /**
    * Initialize from set of rejections
-   * @param {Set} rejections
+   * @param {Set} cosigners
    * @return {RejectionsSetRecord}
    */
 
-  static fromRejections(rejections) {
-    return new this(rejections);
+  static fromSet(cosigners) {
+    return new this().fromSet(cosigners);
   }
 
   /*
@@ -745,6 +743,37 @@ class RejectionsSetRecord extends Struct {
   /*
    * Struct methods
    */
+
+  getJSON() {
+    return this.toArray();
+  }
+
+  fromJSON(json) {
+    enforce(Array.isArray(json), 'json', 'Array');
+    return this.fromArray(json);
+  }
+
+  fromArray(cosigners) {
+    enforce(Array.isArray(cosigners), 'cosigners', 'Array');
+
+    for (const id of cosigners)
+      this.add(id);
+
+    return this;
+  }
+
+  static fromArray(cosigners) {
+    return new this().fromArray(cosigners);
+  }
+
+  toArray() {
+    const cosigners = [];
+
+    for (const id of this.values())
+      cosigners.push(id);
+
+    return cosigners;
+  }
 
   /**
    * Get raw serialization size.
@@ -829,9 +858,10 @@ class RejectionsSetRecord extends Struct {
  * @property {Number} inputs - number of inputs in transaction
  */
 
-class ApprovedMapRecord extends Struct {
-  constructor(options) {
+class ApprovalsMapRecord extends Struct {
+  constructor() {
     super();
+
     this.approvals = new Map();
   }
 
@@ -894,6 +924,24 @@ class ApprovedMapRecord extends Struct {
    * Struct methods.
    */
 
+  getJSON() {
+    const cosigners = [];
+
+    for (const key of this.keys())
+      cosigners.push(key);
+
+    return cosigners;
+  }
+
+  fromJSON(json) {
+    assert(Array.isArray(json), 'json', 'array');
+
+    for (const key of json)
+      this.set(key, new SignaturesRecord());
+
+    return this;
+  }
+
   getSize() {
     let size = 1;
 
@@ -929,7 +977,7 @@ class ApprovedMapRecord extends Struct {
   }
 
   equals(approvedRecord) {
-    assert(ApprovedMapRecord.isApprovedMapRecord(approvedRecord));
+    assert(ApprovalsMapRecord.isApprovalsMapRecord(approvedRecord));
 
     if (approvedRecord.size !== this.size)
       return false;
@@ -947,7 +995,7 @@ class ApprovedMapRecord extends Struct {
     return true;
   }
 
-  static isApprovedMapRecord(obj) {
+  static isApprovalsMapRecord(obj) {
     return obj instanceof this;
   }
 }
@@ -971,6 +1019,16 @@ class SignaturesRecord extends Struct {
 
     if (signatures)
       this.fromSignatures(signatures);
+  }
+
+  getJSON() {
+    return this.toSignatures();
+  }
+
+  fromJSON(json) {
+    this.fromSignatures(json);
+
+    return this;
   }
 
   /**
@@ -1140,7 +1198,7 @@ Proposal.statusMessages = statusMessages;
 Proposal.statussByVal = statusByVal;
 Proposal.status = status;
 Proposal.RejectionsSetRecord = RejectionsSetRecord;
-Proposal.ApprovedMapRecord = ApprovedMapRecord;
+Proposal.ApprovalsMapRecord = ApprovalsMapRecord;
 Proposal.SignaturesRecord = SignaturesRecord;
 
 module.exports = Proposal;

--- a/lib/primitives/proposal.js
+++ b/lib/primitives/proposal.js
@@ -5,13 +5,18 @@
  */
 'use strict';
 
-const assert = require('assert');
+const assert = require('bsert');
 const bcoin = require('bcoin');
-const {Struct} = require('bufio');
+const {encoding, Struct} = require('bufio');
 const {common} = bcoin.wallet;
 const {Outpoint, TX} = bcoin;
 const Cosigner = require('./cosigner');
 const layout = require('../layout').proposaldb;
+
+/**
+ * Signature or null
+ * @typedef {Buffer?} SignatureOption
+ */
 
 /**
  * Proposal status
@@ -661,6 +666,157 @@ class Proposal extends Struct {
   }
 }
 
+/**
+ * Array of signatures
+ * @property {SignatureOption[]} signatures
+ */
+
+class SignaturesRecord extends Struct {
+  /**
+   * Create Signatures Record
+   * @param {(SignatureOption[])?} signatures
+   */
+
+  constructor(signatures) {
+    super();
+
+    this.size = 0;
+    this.signatures = new Map();
+
+    if (signatures)
+      this.fromSignatures(signatures);
+  }
+
+  /**
+   * Get size for raw serialization.
+   * @returns {Number}
+   */
+
+  getSize() {
+    let size = 2; // size and map size
+
+    for (const signature of this.signatures.values())
+      size += 1 + encoding.sizeVarBytes(signature);
+
+    return size;
+  }
+
+  /**
+   * Serialize to raw encoding.
+   * @param {BufferWriter} bw
+   * @returns {BufferWriter}
+   */
+
+  write(bw) {
+    bw.writeU8(this.size);
+    bw.writeU8(this.signatures.size);
+
+    for (const [i, signature] of this.signatures.entries()) {
+      bw.writeU8(i);
+      bw.writeVarBytes(signature);
+    }
+
+    return bw;
+  }
+
+  /**
+   * Deserialize from raw encoding.
+   * @param {BufferReader} br
+   * @returns {SignaturesRecord}
+   */
+
+  read(br) {
+    const size = br.readU8();
+    const mapSize = br.readU8();
+
+    this.size = size;
+
+    for (let i = 0; i < mapSize; i++) {
+      const key = br.readU8();
+      const value = br.readVarBytes();
+
+      this.signatures.set(key, value);
+    }
+
+    return this;
+  }
+
+  /**
+   * Checks SignaturesRecord equality
+   * @param {SignaturesRecord} sigrecord
+   * @returns {Boolean}
+   */
+
+  equals(sigrecord) {
+    assert(SignaturesRecord.isSignatureRecord(sigrecord));
+
+    if (this.signatures.size !== sigrecord.signatures.size)
+      return false;
+
+    for (const [i, signature] of this.signatures.entries()) {
+      const signature2 = sigrecord.signatures.get(i);
+
+      if (!signature2)
+        return false;
+
+      if (!signature.equals(signature2))
+        return false;
+    }
+
+    return true;
+  }
+
+  toSignatures() {
+    const signatures = new Array(this.size);
+
+    for (const [i, signature] of this.signatures.entries())
+      signatures[i] = signature;
+
+    return signatures;
+  }
+
+  /**
+   * create signature record from signatures array
+   * @param {SignatureOption[]} signatures
+   * @returns {SignaturesRecord}
+   */
+
+  fromSignatures(signatures) {
+    assert(Array.isArray(signatures));
+
+    this.size = signatures.length;
+
+    for (const [i, signature] of signatures.entries()) {
+      if (!signature)
+        continue;
+
+      this.signatures.set(i, signature);
+    }
+
+    return this;
+  }
+
+  /**
+   * Checks if obj is SignaturesRecord
+   * @param {Object} obj
+   * @returns {Boolean}
+   */
+
+  static isSignatureRecord(obj) {
+    return obj instanceof SignaturesRecord;
+  }
+
+  /**
+   * Create SignaturesRecord from signatures
+   * @param {SignatureOption[]} signatures
+   * @returns {SignaturesRecord}
+   */
+
+  static fromSignatures(signatures) {
+    return new this(signatures);
+  }
+}
+
 /*
  * Helpers
  */
@@ -697,5 +853,6 @@ function arrayEquals(arr1, arr2) {
 Proposal.statusMessages = statusMessages;
 Proposal.statussByVal = statusByVal;
 Proposal.status = status;
+Proposal.SignaturesRecord = SignaturesRecord;
 
 module.exports = Proposal;

--- a/lib/primitives/proposal.js
+++ b/lib/primitives/proposal.js
@@ -729,7 +729,7 @@ class RejectionsSetRecord extends Struct {
   }
 
   values() {
-    return this.rejections.values()
+    return this.rejections.values();
   }
 
   entries() {
@@ -1177,17 +1177,6 @@ function isU32(number) {
 
 function isU8(number) {
   return (number & 0xff) === number;
-}
-
-function arrayEquals(arr1, arr2) {
-  if (arr1.length !== arr2.length)
-    return false;
-
-  for (let i = 0; i < arr1.length; i++)
-    if (arr1[i] !== arr2[i])
-      return false;
-
-  return true;
 }
 
 /*

--- a/lib/primitives/proposal.js
+++ b/lib/primitives/proposal.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const assert = require('bsert');
+const {enforce} = assert;
 const bcoin = require('bcoin');
 const {encoding, Struct} = require('bufio');
 const {common} = bcoin.wallet;
@@ -667,16 +668,231 @@ class Proposal extends Struct {
 }
 
 /**
+ * Store set of rejections
+ * @property {Set} rejections
+ */
+
+class RejectionsSetRecord extends Struct {
+  /**
+   * Initiate rejection set from set
+   * @param {Set} rejections
+   */
+
+  constructor(rejections) {
+    super();
+
+    this.rejections = new Set();
+
+    if (rejections)
+      this.fromRejections(rejections);
+  }
+
+  fromRejections(rejections) {
+    for (const rejection of rejections.values())
+      this.add(rejection);
+  }
+
+  /**
+   * Initialize from set of rejections
+   * @param {Set} rejections
+   * @return {RejectionsSetRecord}
+   */
+
+  static fromRejections(rejections) {
+    return new this(rejections);
+  }
+
+  /*
+   * Set Methods
+   */
+
+  get size() {
+    return this.rejections.size;
+  }
+
+  add(id) {
+    enforce(isU8(id), 'id', 'u8');
+    this.rejections.add(id);
+    return this;
+  }
+
+  has(id) {
+    enforce(isU8(id), 'id', 'u8');
+    return this.rejections.has(id);
+  }
+
+  delete(id) {
+    enforce(isU8(id), 'id', 'u8');
+    return this.rejections.delete(id);
+  }
+
+  clear() {
+    this.rejections.clear();
+  }
+
+  values() {
+    return this.rejections.values()
+  }
+
+  entries() {
+    return this.rejections.entries();
+  }
+
+  [Symbol.iterator]() {
+    return this.rejections.entries();
+  }
+
+  /*
+   * Struct methods
+   */
+
+  /**
+   * Get raw serialization size.
+   * This is set of U8s.
+   * @returns {Number}
+   */
+
+  getSize() {
+    return this.size + 1;
+  }
+
+  /**
+   * Serialize
+   * @param {BufferWriter} bw
+   * @returns {BufferWriter}
+   */
+
+  write(bw) {
+    bw.writeU8(this.size);
+    for (const value of this.values())
+      bw.writeU8(value);
+
+    return bw;
+  }
+
+  /**
+   * Deserialize
+   * @param {BufferReader} br
+   * @returns {RejectionsSetRecord}
+   */
+
+  read(br) {
+    const size = br.readU8();
+
+    for (let i = 0; i < size; i++) {
+      const key = br.readU8();
+
+      this.add(key);
+    }
+
+    assert(this.size === size, 'Incorrect number of elements.');
+  }
+
+  /**
+   * Check equality to other rejection set record.
+   * @param {RejectionsSetRecord} rejectionsRecord
+   * @returns {Boolean}
+   */
+
+  equals(rejectionsRecord) {
+    enforce(
+      RejectionsSetRecord.isRejectionsSetRecord(rejectionsRecord),
+      'obj',
+      'RejectionsSetRecord'
+    );
+
+    if (rejectionsRecord.size !== this.size)
+      return false;
+
+    for (const value of this.values()) {
+      if (!rejectionsRecord.has(value))
+        return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Is object RejectionsSetRecord?
+   * @param {Object} obj
+   * @returns {Boolean}
+   */
+
+  static isRejectionsSetRecord(obj) {
+    return obj instanceof RejectionsSetRecord;
+  }
+}
+
+/**
  * Store map of signatures by cosigner id
  * @property {Map} approvals
  * @property {Number} inputs - number of inputs in transaction
  */
 
-class ApprovedRecord extends Struct {
+class ApprovedMapRecord extends Struct {
   constructor(options) {
     super();
     this.approvals = new Map();
   }
+
+  /*
+   * Map methods
+   */
+
+  get size() {
+    return this.approvals.size;
+  }
+
+  get(id) {
+    enforce(isU8(id), 'id', 'u8');
+    return this.approvals.get(id);
+  }
+
+  set(id, signatures) {
+    enforce(isU8(id), 'id', 'u8');
+    enforce(
+      SignaturesRecord.isSignatureRecord(signatures),
+      'signatures',
+      'SignaturesRecord'
+    );
+
+    this.approvals.set(id, signatures);
+    return this;
+  }
+
+  has(id) {
+    enforce(isU8(id), 'id', 'u8');
+    return this.approvals.has(id);
+  }
+
+  delete(id) {
+    enforce(isU8(id), 'id', 'u8');
+    return this.approvals.delete(id);
+  }
+
+  clear() {
+    this.approvals.clear();
+  }
+
+  keys() {
+    return this.approvals.keys();
+  }
+
+  values() {
+    return this.approvals.values();
+  }
+
+  entries() {
+    return this.approvals.entries();
+  }
+
+  [Symbol.iterator]() {
+    return this.entries();
+  }
+
+  /*
+   * Struct methods.
+   */
 
   getSize() {
     let size = 1;
@@ -706,20 +922,20 @@ class ApprovedRecord extends Struct {
       const key = br.readU8();
       const value = SignaturesRecord.fromReader(br);
 
-      this.approvals.set(key, value);
+      this.set(key, value);
     }
 
     return this;
   }
 
   equals(approvedRecord) {
-    assert(ApprovedRecord.isApprovedRecord(approvedRecord));
+    assert(ApprovedMapRecord.isApprovedMapRecord(approvedRecord));
 
-    if (approvedRecord.approvals.size !== this.approvals.size)
+    if (approvedRecord.size !== this.size)
       return false;
 
-    for (const [i, sigRecord] of this.approvals.entries()) {
-      const sigRecord2 = approvedRecord.approvals.get(i);
+    for (const [i, sigRecord] of this.entries()) {
+      const sigRecord2 = approvedRecord.get(i);
 
       if (!sigRecord2)
         return false;
@@ -731,24 +947,7 @@ class ApprovedRecord extends Struct {
     return true;
   }
 
-  has(id) {
-    assert(isU8(id));
-    return this.approvals.has(id);
-  }
-
-  get(id) {
-    assert(isU8(id));
-    return this.approvals.get(id);
-  }
-
-  set(id, signatures) {
-    assert(isU8(id));
-    assert(SignaturesRecord.isSignatureRecord(signatures));
-
-    this.approvals.set(id, signatures);
-  }
-
-  static isApprovedRecord(obj) {
+  static isApprovedMapRecord(obj) {
     return obj instanceof this;
   }
 }
@@ -940,7 +1139,8 @@ function arrayEquals(arr1, arr2) {
 Proposal.statusMessages = statusMessages;
 Proposal.statussByVal = statusByVal;
 Proposal.status = status;
-Proposal.ApprovedRecord = ApprovedRecord;
+Proposal.RejectionsSetRecord = RejectionsSetRecord;
+Proposal.ApprovedMapRecord = ApprovedMapRecord;
 Proposal.SignaturesRecord = SignaturesRecord;
 
 module.exports = Proposal;

--- a/lib/primitives/proposal.js
+++ b/lib/primitives/proposal.js
@@ -667,6 +667,93 @@ class Proposal extends Struct {
 }
 
 /**
+ * Store map of signatures by cosigner id
+ * @property {Map} approvals
+ * @property {Number} inputs - number of inputs in transaction
+ */
+
+class ApprovedRecord extends Struct {
+  constructor(options) {
+    super();
+    this.approvals = new Map();
+  }
+
+  getSize() {
+    let size = 1;
+
+    for (const signatures of this.approvals.values()) {
+      size += 1; // number of signatures.
+      size += signatures.getSize();
+    }
+
+    return size;
+  }
+
+  write(bw) {
+    bw.writeU8(this.approvals.size);
+    for (const [key, signatures] of this.approvals.entries()) {
+      bw.writeU8(key);
+      signatures.write(bw);
+    }
+
+    return bw;
+  }
+
+  read(br) {
+    const mapSize = br.readU8();
+
+    for (let i = 0; i < mapSize; i++) {
+      const key = br.readU8();
+      const value = SignaturesRecord.fromReader(br);
+
+      this.approvals.set(key, value);
+    }
+
+    return this;
+  }
+
+  equals(approvedRecord) {
+    assert(ApprovedRecord.isApprovedRecord(approvedRecord));
+
+    if (approvedRecord.approvals.size !== this.approvals.size)
+      return false;
+
+    for (const [i, sigRecord] of this.approvals.entries()) {
+      const sigRecord2 = approvedRecord.approvals.get(i);
+
+      if (!sigRecord2)
+        return false;
+
+      if (!sigRecord.equals(sigRecord2))
+        return false;
+    }
+
+    return true;
+  }
+
+  has(id) {
+    assert(isU8(id));
+    return this.approvals.has(id);
+  }
+
+  get(id) {
+    assert(isU8(id));
+    return this.approvals.get(id);
+  }
+
+  set(id, signatures) {
+    assert(isU8(id));
+    assert(SignaturesRecord.isSignatureRecord(signatures));
+
+    this.approvals.set(id, signatures);
+  }
+
+  static isApprovedRecord(obj) {
+    return obj instanceof this;
+  }
+}
+
+/**
  * Array of signatures
  * @property {SignatureOption[]} signatures
  */
@@ -803,7 +890,7 @@ class SignaturesRecord extends Struct {
    */
 
   static isSignatureRecord(obj) {
-    return obj instanceof SignaturesRecord;
+    return obj instanceof this;
   }
 
   /**
@@ -853,6 +940,7 @@ function arrayEquals(arr1, arr2) {
 Proposal.statusMessages = statusMessages;
 Proposal.statussByVal = statusByVal;
 Proposal.status = status;
+Proposal.ApprovedRecord = ApprovedRecord;
 Proposal.SignaturesRecord = SignaturesRecord;
 
 module.exports = Proposal;

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -6,14 +6,25 @@
 
 'use strict';
 
-const assert = require('assert');
-const {Outpoint, CoinView, MTX} = require('bcoin');
+const assert = require('bsert');
+const {enforce} = assert;
+const {Outpoint, MTX} = require('bcoin');
+const MultisigMTX = require('./primitives/mtx');
 const Proposal = require('./primitives/proposal');
 const {MapLock, Lock} = require('bmutex');
 const layout = require('./layout').proposaldb;
 
+// tmp
+const { PerformanceObserver, performance } = require('perf_hooks');
+
 /**
  * Proposal DB
+ * @property {MultisigDB} msdb
+ * @property {BDB} db
+ * @property {Number} wid
+ * @property {Bucket} bucket
+ * @property {MultisigWallet} wallet
+ * @property {Number} depth
  */
 
 class ProposalDB {
@@ -198,34 +209,6 @@ class ProposalDB {
   }
 
   /**
-   * Get proposal with TX
-   * @param {Number|String} id
-   * @returns {Promise<Proposal>}
-   */
-
-  async getWithTX(id) {
-    const pid = await this.ensurePID(id);
-
-    if (pid === -1)
-      return null;
-
-    const unlock = await this.readLock.lock(pid);
-
-    try {
-      return this._getWithTX(pid);
-    } finally {
-      unlock();
-    }
-  }
-
-  async _getWithTX(pid) {
-    const proposal = await Proposal.getProposalWithTX(this.bucket, pid);
-    proposal.m = this.wallet.m;
-    proposal.n = this.wallet.n;
-    return proposal;
-  }
-
-  /**
    * Get proposal transaction with readLock
    * @param {Number|String} id
    * @returns {Promise<TX?>}
@@ -240,10 +223,58 @@ class ProposalDB {
     const unlock = await this.readLock.lock(pid);
 
     try {
-      return Proposal.getTX(this.bucket, pid);
+      return this._getTX(pid);
     } finally {
       unlock();
     }
+  }
+
+  /**
+   * Get proposal transaction without lock.
+   * @param {Number} id
+   * @returns {Promise<TX?>}
+   */
+
+  _getTX(pid) {
+    return Proposal.getTX(this.bucket, pid);
+  }
+
+  /**
+   * Get proposal transaction with coinview
+   * with lock.
+   * @param {Number|String} id
+   * @returns {Promise<MTX?>}
+   */
+
+  async getMTX(id) {
+    const pid = await this.ensurePID(id);
+
+    if (pid === -1)
+      return null;
+
+    const unlock = await this.readLock.lock(pid);
+
+    try {
+      return this._getMTX(id);
+    } finally {
+      unlock();
+    }
+  }
+
+  /**
+   * Get proposal transaction with coinview
+   * without lock.
+   * @param {Number} id
+   * @returns {Promise<MTX?>}
+   */
+
+  async _getMTX(id) {
+    const tx = await this._getTX(id);
+    const view = await this.wallet.getCoinView(tx);
+    const mtx = MTX.fromTX(tx);
+    mtx.view = view;
+
+    return mtx;
   }
 
   /**
@@ -335,19 +366,24 @@ class ProposalDB {
     const b = this.bucket.batch();
     const id = this.depth;
 
+    const [tx, view] = mtx.commit();
+
+    // Should we store empty MTX,
+    // we will need to clean up inputs
+    // Should we cache relevant information?
+    //  Rings, Paths ? (We are storing coins for reorgs).
     const proposal = Proposal.fromOptions({
       id: id,
       name: name,
       author: cosigner.id,
-      tx: mtx.toTX(),
       m: this.wallet.m,
       n: this.wallet.n
     });
 
     this.increment(b);
 
-    for (const input of mtx.inputs) {
-      const coin = mtx.view.getCoinFor(input);
+    for (const input of tx.inputs) {
+      const coin = view.getCoinFor(input);
 
       if (!coin)
         continue;
@@ -356,7 +392,8 @@ class ProposalDB {
       Proposal.savePIDByCoin(b, coin, proposal.id);
     }
 
-    Proposal.saveProposalWithTX(b, proposal);
+    Proposal.saveProposal(b, proposal);
+    Proposal.saveTX(b, proposal.id, tx);
 
     await b.write();
 
@@ -427,12 +464,12 @@ class ProposalDB {
    * NAIVE
    * @param {Number|String} id
    * @param {Cosigner} cosigner
-   * @param {TX} tx
+   * @param {Buffer[]} signatures
    * @returns {Promise<Proposal>}
    * @throws {Error}
    */
 
-  async approveProposal(id, cosigner, tx) {
+  async approveProposal(id, cosigner, signatures) {
     const pid = await this.ensurePID(id);
 
     if (pid === -1)
@@ -442,57 +479,66 @@ class ProposalDB {
     const unlock2 = await this.writeLock.lock();
 
     try {
-      return this._approveProposal(pid, cosigner, tx);
+      return this._approveProposal(pid, cosigner, signatures);
     } finally {
       unlock2();
       unlock1();
     }
   }
 
-  async _approveProposal(pid, cosigner, tx) {
-    const proposal = await this._getWithTX(pid);
+  async _approveProposal(pid, cosigner, signatures) {
+    enforce(Array.isArray(signatures), 'signatures', 'Array');
 
-    proposal.approve(cosigner);
+    const proposal = await this._getProposal(pid);
+    const mtx = await this._getMTX(pid);
+    const msMTX = MultisigMTX.fromMTX(mtx);
+    msMTX.view = mtx.view;
 
-    // TODO: accept only signatures for inputs
-    // Or extract them from submitted transaction
-    // HACK: save signed transaction for now
-    // with no validation....
-    proposal.tx = tx;
+    const rings = await this.wallet.deriveInputs(mtx);
+    const check = this.deriveRings(cosigner, rings);
+    const valid = msMTX.checkSignatures(rings, signatures);
+
+    if (valid !== check)
+      throw new Error('Signature(s) incorrect.');
+
+    proposal.approve(cosigner, signatures);
 
     if (proposal.isPending()) {
       const b = this.bucket.batch();
-      Proposal.saveProposalWithTX(b, proposal);
+      Proposal.saveProposal(b, proposal);
       await b.write();
       return proposal;
     }
 
-    // tx is approved
-    const coins = await this.getProposalCoins(pid);
-    const view = new CoinView();
-    const mtx = MTX.fromTX(proposal.tx);
+    for (const cosigner of this.wallet.cosigners) {
+      this.deriveRings(cosigner, rings);
 
-    for (const coin of coins) {
-      view.addCoin(coin);
+      const applied = proposal.applySignatures(cosigner.id, msMTX, rings);
+
+      if (!applied)
+        throw new Error('Could not apply.');
     }
 
-    mtx.view = view;
 
-    const verify = mtx.verify();
+    const verify = msMTX.verify();
 
     if (verify) {
       const b = this.bucket.batch();
-      Proposal.saveProposalWithTX(b, proposal);
+      Proposal.saveProposal(b, proposal);
+      Proposal.saveTX(b, proposal.id, msMTX);
       await b.write();
 
       // send the transaction
-      await this.wallet.send(mtx);
+      await this.wallet.send(msMTX.toMTX());
 
       return proposal;
     }
 
-    // incorrect tx / reject tx.
+    // should not happen
     const b = this.bucket.batch();
+
+    // TODO: reuse coins from MTX
+    const coins = await this.getProposalByOutpoint(pid);
 
     for (const coin of coins)
       this.unlockCoin(b, proposal, coin);
@@ -503,6 +549,30 @@ class ProposalDB {
     await b.write();
 
     return proposal;
+  }
+
+  /**
+   * Derive rings for cosigner
+   * @param {Cosigner} cosigner
+   * @param {KeyRing[]} rings
+   * @returns {Number} - number of rings
+   */
+
+  deriveRings(cosigner, rings) {
+    let check = 0;
+
+    for (const ring of rings) {
+      if (!ring)
+        continue;
+
+      const pubkey = cosigner.deriveKey(ring.branch, ring.index).publicKey;
+      ring.publicKey = pubkey;
+      ring.witness = this.wallet.witness;
+      ring.nested = ring.branch === 2;
+      check++;
+    }
+
+    return check;
   }
 
   /**

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -14,9 +14,6 @@ const Proposal = require('./primitives/proposal');
 const {MapLock, Lock} = require('bmutex');
 const layout = require('./layout').proposaldb;
 
-// tmp
-const { PerformanceObserver, performance } = require('perf_hooks');
-
 /**
  * Proposal DB
  * @property {MultisigDB} msdb
@@ -518,7 +515,6 @@ class ProposalDB {
       if (!applied)
         throw new Error('Could not apply.');
     }
-
 
     const verify = msMTX.verify();
 

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -487,6 +487,10 @@ class ProposalDB {
     enforce(Array.isArray(signatures), 'signatures', 'Array');
 
     const proposal = await this._getProposal(pid);
+
+    // fail early.
+    assert(proposal.isPending(), 'Proposal is not pending.');
+
     const mtx = await this._getMTX(pid);
     const msMTX = MultisigMTX.fromMTX(mtx);
     msMTX.view = mtx.view;
@@ -507,6 +511,7 @@ class ProposalDB {
       return proposal;
     }
 
+    // save signed proposal.
     for (const cosigner of this.wallet.cosigners) {
       this.deriveRings(cosigner, rings);
 
@@ -523,9 +528,6 @@ class ProposalDB {
       Proposal.saveProposal(b, proposal);
       Proposal.saveTX(b, proposal.id, msMTX);
       await b.write();
-
-      // send the transaction
-      await this.wallet.send(msMTX.toMTX());
 
       return proposal;
     }
@@ -650,6 +652,39 @@ class ProposalDB {
 
       writeUnlock();
     }
+  }
+
+  /**
+   * Send approved proposal.
+   * @param {Number|String} id
+   * @returns {Promise<TX>}
+   * @throws {Error}
+   */
+
+  async sendProposal(id) {
+    const pid = await this.ensurePID(id);
+
+    if (pid === -1)
+      throw new Error('Proposal not found.');
+
+    const unlock = await this.readLock.lock(pid);
+
+    try {
+      return this._sendProposal(pid);
+    } finally {
+      unlock();
+    }
+  }
+
+  async _sendProposal(pid) {
+    const proposal = await this._getProposal(pid);
+
+    assert(proposal.isApproved(), 'Can only send approved proposal tx.');
+
+    const tx = await this._getTX(pid);
+    await this.wallet.send(tx);
+
+    return tx;
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -795,8 +795,19 @@ class MultisigWallet {
    * @throws {Error}
    */
 
-  async approveProposal(name, cosigner, signatures) {
+  approveProposal(name, cosigner, signatures) {
     return this.pdb.approveProposal(name, cosigner, signatures);
+  }
+
+  /**
+   * Broadcast proposal mtx.
+   * @param {Number|String} id
+   * @returns {Promise<TX>}
+   * @throws {Error}
+   */
+
+  sendProposal(name) {
+    return this.pdb.sendProposal(name);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -60,8 +60,11 @@ class MultisigWallet {
 
     this.wid = 0;
     this.id = null;
+
+    // cache account data
     this.n = 0;
     this.m = 0;
+    this.witness = false;
     this.cosigners = [];
     this.joinKey = null;
     this.master = new MasterKey();
@@ -97,6 +100,11 @@ class MultisigWallet {
     if (options.id != null) {
       assert(common.isName(options.id), 'Bad wallet ID.');
       this.id = options.id;
+    }
+
+    if (options.witness != null) {
+      assert(typeof options.witness === 'boolean');
+      this.witness = options.witness;
     }
 
     if (options.m != null) {
@@ -186,6 +194,7 @@ class MultisigWallet {
     return {
       id: this.id,
       wid: this.wid,
+      witness: this.witness,
       m: this.m,
       n: this.n,
       initialized: this.isInitialized(),
@@ -235,7 +244,7 @@ class MultisigWallet {
   getSize() {
     let size = 0;
 
-    size += 35;
+    size += 36;
     size += this.master.getSize();
 
     for (const cosigner of this.cosigners) {
@@ -256,6 +265,12 @@ class MultisigWallet {
     const size = this.getSize();
     const bw = bio.write(size);
 
+    let flags = 0;
+
+    if (this.witness)
+      flags |= 1;
+
+    bw.writeU8(flags);
     bw.writeU8(this.m);
     bw.writeU8(this.n);
     bw.writeBytes(this.joinKey);
@@ -277,6 +292,9 @@ class MultisigWallet {
   fromRaw(data) {
     const br = bio.read(data);
 
+    const flags = br.readU8();
+
+    this.witness = (flags & 1) !== 1;
     this.m = br.readU8();
     this.n = br.readU8();
     this.joinKey = br.readBytes(32);

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -468,12 +468,11 @@ class MultisigWallet {
    * @returns {Promise<MultisigWallet>}
    */
 
-  join(cosigner, xpub) {
+  join(cosigner) {
     assert(this.cosigners.length < this.n, 'Multisig wallet is full.');
     assert(cosigner instanceof Cosigner, 'Join needs cosigner.');
-    assert(xpub instanceof HDPublicKey, 'Join needs HDPublicKey.');
 
-    return this.msdb.join(this.wid, cosigner, xpub);
+    return this.msdb.join(this.wid, cosigner);
   }
 
   /**
@@ -541,6 +540,8 @@ class MultisigWallet {
   /**
    * Create transaction
    * This won't lock the coins
+   * NOTE: Transaction will not have
+   * input scripts/witness scripted.
    * @async
    * @param {Object} options
    * @param {Number} options.rate - fee calculation rate
@@ -580,12 +581,12 @@ class MultisigWallet {
   }
 
   /**
-   * NAIVE !
    * Create proposal
    * @async
    * @param {String} name
    * @param {Cosigner} cosigner
    * @param {Object} txoptions
+   * @returns {Proposal}
    */
 
   async createProposal(name, cosigner, txoptions) {
@@ -604,6 +605,7 @@ class MultisigWallet {
    * @param {String} name
    * @param {Cosigner} cosigner
    * @param {Object} txoptions
+   * @returns {Proposal}
    */
 
   async _createProposal(name, cosigner, txoptions) {
@@ -622,17 +624,6 @@ class MultisigWallet {
 
   getProposal(id) {
     return this.pdb.getProposal(id);
-  }
-
-  /**
-   * Get proposal with TX
-   * @async
-   * @param {String|Number} id
-   * @returns {Promise<Proposal?>}
-   */
-
-  getProposalWithTX(id) {
-    return this.pdb.getWithTX(id);
   }
 
   /**
@@ -742,16 +733,28 @@ class MultisigWallet {
       paths = await this.getInputPaths(mtx);
 
     const rings = [];
+    const account = await this.getAccount();
 
     for (const path of paths) {
-      const account = await this.getAccount();
       const ring = account.derivePath(path);
 
-      if (ring)
+      if (!ring)
+        rings.push(null);
+      else
         rings.push(ring);
     }
 
     return rings;
+  }
+
+   /**
+   * Get a coin viewpoint.
+   * @param {TX} tx
+   * @returns {Promise<CoinView>}
+   */
+
+  getCoinView(tx) {
+    return this.wallet.getCoinView(tx);
   }
 
   /**
@@ -788,13 +791,13 @@ class MultisigWallet {
    * Approve proposal
    * @param {Number|String} id
    * @param {Cosigner} cosigner
-   * @param {TX} tx
+   * @param {Buffer[]} signatures
    * @returns {Promise<Proposal>}
    * @throws {Error}
    */
 
-  approveProposal(name, cosigner, tx) {
-    return this.pdb.approveProposal(name, cosigner, tx);
+  async approveProposal(name, cosigner, signatures) {
+    return this.pdb.approveProposal(name, cosigner, signatures);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -15,7 +15,6 @@ const bcoin = require('bcoin');
 const Wallet = bcoin.wallet.Wallet;
 const {common, MasterKey} = bcoin.wallet;
 const {encoding} = bio;
-const HDPublicKey = bcoin.hd.HDPublicKey;
 const {MTX} = bcoin;
 
 const ProposalDB = require('./proposaldb');

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -293,7 +293,7 @@ class MultisigWallet {
 
     const flags = br.readU8();
 
-    this.witness = (flags & 1) !== 1;
+    this.witness = (flags & 1) === 1;
     this.m = br.readU8();
     this.n = br.readU8();
     this.joinKey = br.readBytes(32);

--- a/test/cosigner-test.js
+++ b/test/cosigner-test.js
@@ -6,7 +6,6 @@
 const assert = require('./util/assert');
 const Cosigner = require('../lib/primitives/cosigner');
 const {hd} = require('bcoin');
-const {HDPublicKey} = hd;
 
 // This path does not do much.
 const TEST_PATH = 'm/44\'/0\'/0\'/0/0';

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -465,7 +465,7 @@ describe('HTTP', function () {
     const txinfo = await testWalletClient1.getProposalMTX(
       WALLET_OPTIONS.id,
       'proposal2',
-      { path: true }
+      { paths: true }
     );
 
     const mtx = MTX.fromJSON(txinfo.tx);
@@ -483,7 +483,7 @@ describe('HTTP', function () {
       WALLET_OPTIONS.id,
       'proposal2',
       {
-        path: true,
+        paths: true,
         scripts: true
       }
     );
@@ -519,7 +519,7 @@ describe('HTTP', function () {
       WALLET_OPTIONS.id,
       'proposal2',
       {
-        path: true,
+        paths: true,
         scripts: true
       }
     );

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -9,10 +9,9 @@ const testUtils = require('./util/utils');
 
 const bcoin = require('bcoin');
 const {Network, FullNode} = bcoin;
-const {Script, CoinView, Coin, MTX, TX, Amount, KeyRing} = bcoin;
+const {MTX, TX, Amount, KeyRing} = bcoin;
 const {wallet, hd} = bcoin;
 const Proposal = require('../lib/primitives/proposal');
-const MultisigMTX = require('../lib/primitives/mtx');
 
 const MultisigClient = require('../lib/client');
 const {WalletClient} = require('bclient');
@@ -58,9 +57,7 @@ const walletNode = new wallet.Node({
 
 const wdb = walletNode.wdb;
 
-//walletNode.on('error', err => console.error(err));
-
-const TEST_XPUB_PATH = 'm/44\'/0\'/0\'';
+// walletNode.on('error', err => console.error(err));
 
 const WALLET_OPTIONS = {
   m: 2,
@@ -86,8 +83,8 @@ describe('HTTP', function () {
   let testWalletClient2;
   let joinKey;
 
-  const priv1 = getPrivKey().deriveAccount(44, 0, 0)
-  const priv2 = getPrivKey().deriveAccount(44, 0, 0)
+  const priv1 = getPrivKey().deriveAccount(44, 0, 0);
+  const priv2 = getPrivKey().deriveAccount(44, 0, 0);
   const xpub1 = priv1.toPublic();
   const xpub2 = priv2.toPublic();
 
@@ -493,7 +490,6 @@ describe('HTTP', function () {
 
     const mtx = MTX.fromJSON(txinfo.tx);
     const paths = txinfo.paths;
-    const scripts = txinfo.scripts;
 
     const rings = testUtils.getMTXRings(mtx, paths, priv1, [xpub1, xpub2], 2);
 
@@ -530,7 +526,6 @@ describe('HTTP', function () {
 
     const mtx = MTX.fromJSON(txinfo.tx);
     const paths = txinfo.paths;
-    const scripts = txinfo.scripts;
 
     const rings = testUtils.getMTXRings(mtx, paths, priv2, [xpub1, xpub2], 2);
 
@@ -542,8 +537,6 @@ describe('HTTP', function () {
     }
 
     const signatures = testUtils.getMTXSignatures(mtx, rings);
-
-
     const proposal = await testWalletClient2.approveProposal(
       WALLET_OPTIONS.id,
       'proposal2',

--- a/test/mtx-test.js
+++ b/test/mtx-test.js
@@ -1,0 +1,205 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('./util/assert');
+const MultisigMTX = require('../lib/primitives/mtx');
+const {KeyRing, Script, Coin} = require('bcoin');
+
+const utils = require('./util/wallet');
+
+// 1 BTC
+const BTC = 100000000;
+
+describe('MultisigMTX', function () {
+  for (const witness of [true, false]) {
+    it(`should get input signature (witness=${witness})`, async () => {
+      const ring = createRing(witness);
+      const ring2 = createRing(witness);
+      const {mtx, coin} = await createSpendingTX(ring, BTC);
+
+      // sign duplicate tx
+      const signedMTX = mtx.clone();
+      signedMTX.view = mtx.view;
+
+      const isWitness = mtx.isWitnessCoin(coin, ring);
+      assert.strictEqual(isWitness, witness);
+
+      const signed = signedMTX.sign(ring);
+      assert(signed, 'Could not sign transaction.');
+
+      let sig;
+      {
+        // get signature from input
+        const input = signedMTX.inputs[0];
+        const signScript = isWitness ? input.witness : input.script;
+        const vector = signScript.toStack();
+
+        sig = vector.get(0);
+      }
+
+      const sig2 = mtx.getInputSignature(0, coin, ring);
+      const check1 = mtx.checkSignature(0, coin, ring, sig);
+
+      assert.bufferEqual(sig2, sig);
+      assert.strictEqual(check1, true);
+
+      let err;
+      try {
+        mtx.checkSignature(0, coin, ring2, sig);
+      } catch (e) {
+        err = e;
+      }
+
+      assert(err);
+      assert.strictEqual(err.message, 'Coin does not belong to the ring.');
+
+      // apply signature
+      sig = null;
+      err = null;
+
+      mtx.scriptInput(0, coin, ring);
+      let applied = mtx.applySignature(0, coin, ring, sig2);
+
+      assert.strictEqual(applied, true);
+
+      {
+        const input = mtx.inputs[0];
+        const signScript = isWitness ? input.witness : input.script;
+        const vector = signScript.toStack();
+
+        sig = vector.get(0);
+      }
+
+      assert.bufferEqual(sig, sig2);
+
+      // reset mtx input
+      applied = mtx.applySignature(0, coin, ring2, sig2);
+      assert.strictEqual(applied, false);
+    });
+
+    it(`should get input signature multisig (witness=${witness})`, async () => {
+      // generate keys
+      const [ring1, ring2] = createMultisigRings(witness);
+      const {mtx, coin} = await createSpendingTX(ring1, BTC);
+
+      const signedMTX = mtx.clone();
+      signedMTX.view = mtx.view;
+
+      const isWitness = mtx.isWitnessCoin(coin, ring1);
+      assert.strictEqual(isWitness, witness);
+
+      // sign with first key.
+      const signed = signedMTX.sign(ring1);
+      assert(signed, 'Could not sign transaction.');
+
+      let sig;
+
+      {
+        const input = signedMTX.inputs[0];
+        const signScript = isWitness ? input.witness : input.script;
+        const vector = signScript.toStack();
+
+        // get signatures from stack
+        const [sig1, sig2] = [vector.get(1), vector.get(2)];
+        sig = sig1.length > 0 ? sig1 : sig2;
+      }
+
+      // choose correct signature
+      const sig2 = mtx.getInputSignature(0, coin, ring1);
+
+      assert.bufferEqual(sig2, sig, 'Signature is not correct.');
+      assert.strictEqual(mtx.checkSignature(0, coin, ring1, sig), true);
+      assert.strictEqual(mtx.checkSignature(0, coin, ring2, sig), false);
+
+      mtx.scriptInput(0, coin, ring1);
+
+      const applied = mtx.applySignature(0, coin, ring1, sig);
+      assert.strictEqual(applied, true);
+
+      sig = null;
+
+      {
+        const input = mtx.inputs[0];
+        const signScript = isWitness ? input.witness : input.script;
+        const vector = signScript.toStack();
+
+        // get signatures from stack
+        const [sig1, sig2] = [vector.get(1), vector.get(2)];
+        sig = sig1.length > 0 ? sig1 : sig2;
+      }
+
+      assert.bufferEqual(sig, sig2);
+    });
+  }
+});
+
+/**
+ * Create multisig 2-of-2 keyrings
+ * @ignore
+ * @param {Boolean} witness
+ * @returns {[KeyRing, KeyRing]}
+ */
+
+function createMultisigRings(witness) {
+  const key1 = KeyRing.generate(true);
+  const key2 = KeyRing.generate(true);
+
+  key1.witness = witness;
+  key2.witness = witness;
+
+  const [pub1, pub2] = [key1.publicKey, key2.publicKey];
+
+  const script = Script.fromMultisig(2, 2, [pub1, pub2]);
+  key1.script = script;
+  key2.script = script;
+
+  return [key1, key2];
+}
+
+/**
+ * Create p2pkh keyring
+ * @ignore
+ * @param {Boolean} witness
+ * @returns {KeyRing}
+ */
+
+function createRing(witness) {
+  const key = KeyRing.generate(true);
+
+  key.witness = witness;
+
+  return key;
+}
+
+/*
+ * Create spending transaction
+ * 1 input, send from ourselves to ourselves.
+ * @ignore
+ * @param {KeyRing} ring
+ * @param {Number} value
+ * @return {MultisigMTX}
+ */
+
+async function createSpendingTX(ring, value) {
+  const address = ring.getAddress();
+  const fundTX = utils.createFundTX(address, value);
+
+  const coin = Coin.fromTX(fundTX, 0, -1);
+  const mtx = new MultisigMTX();
+
+  // send money to ourselves.
+  mtx.addOutput({ address, value });
+
+  // fund tx
+  await mtx.fund([coin], {
+    changeAddress: address,
+    rate: 0
+  });
+
+  return {
+    mtx: mtx,
+    coin: coin
+  };
+}

--- a/test/mtx-test.js
+++ b/test/mtx-test.js
@@ -142,8 +142,8 @@ describe('MultisigMTX', function () {
       const [ring1, ring2] = createMultisigRings(witness);
       const {mtx} = await createSpendingTX(ring1, BTC, 2);
 
-      const sigs1 = mtx.getSignatures(ring1);
-      const sigs2 = mtx.getSignatures(ring2);
+      const sigs1 = mtx.getSignatures([ring1, ring1]);
+      const sigs2 = mtx.getSignatures([ring2, ring2]);
       const rings1 = [ring1, ring1];
       const rings2 = [ring2, ring2];
 

--- a/test/mtx-test.js
+++ b/test/mtx-test.js
@@ -144,9 +144,20 @@ describe('MultisigMTX', function () {
 
       const sigs1 = mtx.getSignatures(ring1);
       const sigs2 = mtx.getSignatures(ring2);
+      const rings1 = [ring1, ring1];
+      const rings2 = [ring2, ring2];
 
-      mtx.applySignatures(ring1, sigs1, true);
-      mtx.applySignatures(ring2, sigs2, true);
+      mtx.applySignatures(rings1, sigs1, true);
+      mtx.applySignatures(rings2, sigs2, true);
+
+      assert.strictEqual(mtx.checkSignatures(rings1, sigs1), 2);
+      assert.strictEqual(mtx.checkSignatures(rings2, sigs2), 2);
+
+      assert.strictEqual(mtx.checkSignatures([ring1, ring2], sigs1), 1);
+      assert.strictEqual(mtx.checkSignatures([ring1, ring2], sigs2), 1);
+
+      assert.strictEqual(mtx.checkSignatures(rings2, sigs1), 0);
+      assert.strictEqual(mtx.checkSignatures(rings1, sigs2), 0);
 
       assert.strictEqual(mtx.isSigned(), true, 'MTX is not signed.');
       assert.strictEqual(mtx.verify(), true, 'MTX verification failed.');

--- a/test/proposal-test.js
+++ b/test/proposal-test.js
@@ -6,7 +6,9 @@
 const assert = require('./util/assert');
 const Proposal = require('../lib/primitives/proposal');
 const Cosigner = require('../lib/primitives/cosigner');
-const {ApprovedRecord, SignaturesRecord} = Proposal;
+const {ApprovedMapRecord} = Proposal;
+const {RejectionsSetRecord} = Proposal;
+const {SignaturesRecord} = Proposal;
 const {hd} = require('bcoin');
 
 const TEST_OPTIONS = {
@@ -218,15 +220,50 @@ describe('Proposal', function () {
     });
   });
 
-  describe('ApprovedRecord', function () {
+  describe('RejectionsSetRecord', function () {
+    it('should create empty rejections set', () => {
+      const rejRecord1 = new RejectionsSetRecord();
+
+      assert.strictEqual(rejRecord1.size, 0);
+
+      const raw = rejRecord1.toRaw();
+      const rejRecord2 = RejectionsSetRecord.fromRaw(raw);
+
+      assert.bufferEqual(raw, Buffer.from([0x00]));
+
+      assert.strictEqual(rejRecord2.size, 0);
+      assert.strictEqual(rejRecord1.equals(rejRecord2), true);
+    });
+
+    it('should initialize record', () => {
+      const elements = new Set([3, 5, 2, 10]);
+      const rejRecord1 = RejectionsSetRecord.fromRejections(elements);
+
+      assert.strictEqual(rejRecord1.size, 4);
+
+      const raw = rejRecord1.toRaw();
+
+      assert.bufferEqual(
+        raw,
+        Buffer.from('040305020a', 'hex')
+      );
+
+      const rejRecord2 = RejectionsSetRecord.fromRaw(raw);
+
+      assert.strictEqual(rejRecord2.size, 4);
+      assert.strictEqual(rejRecord1.equals(rejRecord2), true);
+    });
+  });
+
+  describe('ApprovedMapRecord', function () {
     it('should create empty record', () => {
-      const approvedRecord = new ApprovedRecord();
+      const approvedRecord = new ApprovedMapRecord();
 
       assert.strictEqual(approvedRecord.approvals.size, 0);
     });
 
     it('should reserialize empty record', () => {
-      const approvedRecord = new ApprovedRecord();
+      const approvedRecord = new ApprovedMapRecord();
       const raw = approvedRecord.toRaw();
 
       assert.bufferEqual(
@@ -234,14 +271,14 @@ describe('Proposal', function () {
         Buffer.from([0x00])
       );
 
-      const approvedRecord2 = ApprovedRecord.fromRaw(raw);
+      const approvedRecord2 = ApprovedMapRecord.fromRaw(raw);
 
       assert.strictEqual(approvedRecord.equals(approvedRecord2), true);
     });
 
     it('should reserialize approved record', () => {
       const sigRecord = new SignaturesRecord();
-      const approvedRecord = new ApprovedRecord();
+      const approvedRecord = new ApprovedMapRecord();
 
       approvedRecord.set(0, sigRecord);
 
@@ -251,7 +288,7 @@ describe('Proposal', function () {
         Buffer.from('01000000', 'hex')
       );
 
-      const approvedRecord2 = ApprovedRecord.fromRaw(raw);
+      const approvedRecord2 = ApprovedMapRecord.fromRaw(raw);
 
       assert.strictEqual(approvedRecord.equals(approvedRecord2), true);
     });
@@ -266,7 +303,7 @@ describe('Proposal', function () {
       const hexSig1 = sigRecord1.toHex();
       const hexSig2 = sigRecord2.toHex();
 
-      const approvedRecord1 = new ApprovedRecord();
+      const approvedRecord1 = new ApprovedMapRecord();
 
       approvedRecord1.set(0, sigRecord1);
       approvedRecord1.set(1, sigRecord2);
@@ -278,7 +315,7 @@ describe('Proposal', function () {
         Buffer.from(`0200${hexSig1}01${hexSig2}`, 'hex')
       );
 
-      const approvedRecord2 = ApprovedRecord.fromRaw(raw);
+      const approvedRecord2 = ApprovedMapRecord.fromRaw(raw);
 
       assert.strictEqual(approvedRecord1.equals(approvedRecord2), true);
     });

--- a/test/proposal-test.js
+++ b/test/proposal-test.js
@@ -6,6 +6,7 @@
 const assert = require('./util/assert');
 const Proposal = require('../lib/primitives/proposal');
 const Cosigner = require('../lib/primitives/cosigner');
+const {hd} = require('bcoin');
 
 const TEST_OPTIONS = {
   id: 1,
@@ -14,6 +15,8 @@ const TEST_OPTIONS = {
   n: 3,
   author: 0
 };
+
+const TEST_KEY = hd.generate().toPublic();
 
 describe('Proposal', function () {
   it('should create proposal from option', () => {
@@ -51,12 +54,14 @@ describe('Proposal', function () {
     const proposal = Proposal.fromOptions(TEST_OPTIONS);
     const cosigner1 = Cosigner.fromOptions({
       id: 0,
-      name: 'cosigner1'
+      name: 'cosigner1',
+      key: TEST_KEY
     });
 
     const cosigner2 = Cosigner.fromOptions({
       id: 1,
-      name: 'cosigner2'
+      name: 'cosigner2',
+      key: TEST_KEY
     });
 
     proposal.reject(cosigner1);
@@ -86,12 +91,14 @@ describe('Proposal', function () {
     const proposal = Proposal.fromOptions(TEST_OPTIONS);
     const cosigner1 = Cosigner.fromOptions({
       id: 0,
-      name: 'cosigner1'
+      name: 'cosigner1',
+      key: TEST_KEY
     });
 
     const cosigner2 = Cosigner.fromOptions({
       id: 1,
-      name: 'cosigner2'
+      name: 'cosigner2',
+      key: TEST_KEY
     });
 
     proposal.approve(cosigner1);

--- a/test/proposals-test.js
+++ b/test/proposals-test.js
@@ -15,7 +15,6 @@ const WalletNodeClient = require('../lib/walletclient');
 const MultisigDB = require('../lib/multisigdb');
 const Cosigner = require('../lib/primitives/cosigner');
 const Proposal = require('../lib/primitives/proposal');
-const MultisigMTX = require('../lib/primitives/mtx');
 
 const TEST_WALLET_ID = 'test';
 const TEST_COSIGNER_1 = 'cosigner1';
@@ -446,7 +445,7 @@ describe('MultisigProposals', function () {
     const rings = testUtils.getMTXRings(mtx, paths, priv1, [xpub1, xpub2], 2);
     const signatures = testUtils.getMTXSignatures(mtx, rings);
 
-    const res = await mswallet.approveProposal(
+    await mswallet.approveProposal(
       'proposal',
       cosigner1,
       signatures
@@ -475,7 +474,6 @@ describe('MultisigProposals', function () {
     assert.strictEqual(pending.length, 1);
 
     const approve = async (priv, cosigner) => {
-      const proposal = await mswallet.getProposal('proposal');
       const mtx = await mswallet.getProposalMTX('proposal');
       const paths = await mswallet.getInputPaths(mtx);
 

--- a/test/util/utils.js
+++ b/test/util/utils.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const bcoin = require('bcoin');
+const {MTX, KeyRing, Script} = bcoin;
+const MultisigMTX = require('../../lib/primitives/mtx');
+
+exports.getMTXSignatures = getMTXSignatures;
+
+
+/**
+ * Get MTX Signatures
+ * @param {MTX} mtx
+ * @param {Path[]} paths
+ * @param {HDPrivateKey} xpriv
+ * @param {HDPublicKey[]} xpubs
+ * @param {Number} [m = 2]
+ * @param {Boolean} [witness = false]
+ * @returns {Buffer[]} - signatures
+ */
+
+function getMTXSignatures(mtx, rings) {
+  let msMTX = mtx;
+
+  if (!MultisigMTX.isMultisigMTX(mtx) && MTX.isMTX(mtx))
+    msMTX = MultisigMTX.fromMTX(mtx);
+
+  msMTX.view = mtx.view;
+
+  return msMTX.getSignatures(rings);
+}
+
+/**
+ * Get MTX Rings
+ * @param {MTX} mtx
+ * @param {Path[]} paths
+ * @param {HDPrivateKey} xpriv
+ * @param {HDPublicKey[]} xpubs
+ * @param {Number} [m = 2]
+ * @returns {Buffer[]} - signatures
+ */
+
+function getMTXRings(mtx, paths, xpriv, xpubs, m = 2) {
+  const msMTX = MultisigMTX.fromMTX(mtx);
+  msMTX.view = mtx.view;
+
+  const rings = new Array(mtx.inputs.length);
+
+  // sign transaction cosigner1
+  mtx.inputs.forEach((input, i) => {
+    const path = paths[i];
+
+    if (!path)
+      return;
+
+    // derive correct priv key
+    const priv = xpriv.derive(path.branch).derive(path.index);
+
+    // derive pubkeys
+    const pubkeys = xpubs.map((pubkey) => {
+      return pubkey.derive(path.branch).derive(path.index).publicKey;
+    });
+
+    const ring = KeyRing.fromPrivate(priv.privateKey);
+
+    ring.script = Script.fromMultisig(
+      m,
+      pubkeys.length,
+      pubkeys
+    );
+
+    rings[i] = ring;
+  });
+
+  return rings;
+}
+
+/*
+ * Expose
+ */
+
+exports.getMTXSignatures = getMTXSignatures;
+exports.getMTXRings = getMTXRings;

--- a/test/util/utils.js
+++ b/test/util/utils.js
@@ -6,7 +6,6 @@ const MultisigMTX = require('../../lib/primitives/mtx');
 
 exports.getMTXSignatures = getMTXSignatures;
 
-
 /**
  * Get MTX Signatures
  * @param {MTX} mtx

--- a/test/wallet-test.js
+++ b/test/wallet-test.js
@@ -362,7 +362,8 @@ describe('MultisigWallet', function () {
       n: 2
     };
 
-    const cosigner = Cosigner.fromOptions({ name: 'cosigner1', key: getPubKey() });
+    const xpub = getPubKey();
+    const cosigner = Cosigner.fromOptions({ name: 'cosigner1', key: xpub });
     const mswallet = await msdb.create(options, cosigner);
     assert.strictEqual(mswallet.isInitialized(), false);
 


### PR DESCRIPTION
Currently when approving Proposal you send signed MTX that overwrites existing and is then shared with other cosigners, MTX(partially signed) is not verified if signatures are correct, also it's possible to overwrite existing MTX with totally different MTX. Also leaves space for race conditions when signing (in case of non-faulty cosigners).
This was implemented in short notice and that's one of the reasons project is not ready for production use.

This PR will change API Call for approving proposal, it will accept array of signatures(corresponding to inputs) that will be verified against MTX provided on proposal creation. If at least one of the signatures in array is not valid using cosigners XPUB(derived for the address), request will fail. Otherwise it will be stored in database and will be merged once enough cosigners have signed the tx. If input belongs to wallet it should be signed, if it does not you can send `null`.

Tasks:
 - [x] MTX additional methods.
 - [x] Store xpub with cosigner as well.
   - [x] Create wallet.
   - [x] join wallet.
   - NOTE: because shared keys are sorted in main db, it's easier to also store them with cosigner.
 - [x] Change HTTP Api for wallet, enforce signatures array.
 - [x] approve proposal
- [x] proposal records
  - [x] ApprovalsMapRecord - map cosignerId -> approvals
  - [x] SignaturesRecord - map input -> signature
  - [x] RejectionsSetRecord - Set of cosigner ids.

Tests:
- [x] MTX method tests.
- [x] update tests
- [x] proposal records

Other:
 - [x] use `cors` option.
 - [x] remove proposal.tx. (They are stored separately, so there's no need for Proposal to have `tx` field)
   - [x] accept `tx` with `toJSON`
 - [x] **Update dependencies**

TODO:
 - *Require ownership proof when create/joining with xpub*