### PR TITLE
correct "n is less than 2" warning

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -122,7 +122,7 @@ class MultisigWallet {
         this.cosigners.push(Cosigner.fromOptions(cosignerOptions));
     }
 
-    assert(this.n > 1, 'n is less than 2');
+    assert(this.n > 1, 'n must be greater than 1');
     assert(this.m >= 1 && this.m <= this.n, 'm ranges between 1 and n.');
 
     return this;

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -122,7 +122,7 @@ class MultisigWallet {
         this.cosigners.push(Cosigner.fromOptions(cosignerOptions));
     }
 
-    assert(this.n > 1, 'n is less than 1');
+    assert(this.n > 1, 'n is less than 2');
     assert(this.m >= 1 && this.m <= this.n, 'm ranges between 1 and n.');
 
     return this;


### PR DESCRIPTION
Actual test is `assert( n > 1 ...`
I was accidentally trying to create a 1-of-1 multisig wallet and got the error `n is less than 1` which I thought was funny. Technically the error is that `n` must be 2 or greater.