### PR TITLE
bugfix: reference property of null

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -155,6 +155,10 @@ class MultisigClient extends WalletClient {
   async getWallets() {
     const wallets = await this.get('/');
 
+    // returns null when not configured properly
+    if (!wallets)
+      return wallets;
+
     return wallets.wallets;
   }
 


### PR DESCRIPTION
Prevents the server from breaking when trying to reference a property on `null`
This error ends up on the frontend when the node server and the wallet server are not configured properly