### PR TITLE
Fix approve proposal.

### DIFF
--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -511,11 +511,12 @@ class ProposalDB {
       return proposal;
     }
 
-    // save signed proposal.
-    for (const cosigner of this.wallet.cosigners) {
+    for (const id of proposal.approvals.keys()) {
+      const cosigner = this.wallet.cosigners[id];
+
       this.deriveRings(cosigner, rings);
 
-      const applied = proposal.applySignatures(cosigner.id, msMTX, rings);
+      const applied = proposal.applySignatures(id, msMTX, rings);
 
       if (!applied)
         throw new Error('Could not apply.');


### PR DESCRIPTION
It was trying to get signatures from every cosigner, where it should only get signatures of cosigners who approved and provided signatures.
It would have failed even if first and third cosigners signed transactions. (2-of-3)
- Fixes #30 
- Provide test case.

