### PR TITLE
proposals: change name to memo

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -458,11 +458,15 @@ class MultisigClient extends WalletClient {
    * @param {String} id
    * @param {String} pid - proposal id
    * @param {Buffer[]} signatures
+   * @param {Boolean} broadcast
    * @returns {Promise<Proposal>}
    */
 
-  approveProposal(id, pid, signatures) {
-    return this.post(`/${id}/proposal/${pid}/approve`, { signatures });
+  approveProposal(id, pid, signatures, broadcast) {
+    return this.post(`/${id}/proposal/${pid}/approve`, {
+      signatures,
+      broadcast
+    });
   }
 
   /**
@@ -766,12 +770,13 @@ class MultisigWallet extends EventEmitter {
   /**
    * Approve proposal
    * @param {String} pid - proposal id
-   * @param {Buffer} tx - raw signed tx
+   * @param {Buffer[]} signatures
+   * @param {Boolean} broadcast
    * @returns {Promise<Proposal>}
    */
 
-  approveProposal(pid, tx) {
-    return this.client.approveProposal(this.id, pid, tx);
+  approveProposal(pid, signatures, broadcast) {
+    return this.client.approveProposal(this.id, pid, signatures, broadcast);
   }
 
   /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -419,30 +419,29 @@ class MultisigClient extends WalletClient {
   /**
    * Create proposal
    * @param {String} id
-   * @param {String} name - proposal name
    * @param {Object} options - transaction options
    * @returns {Promise<Proposal>}
    */
 
-  createProposal(id, name, options) {
-    return this.put(`/${id}/proposal/${name}`, options);
+  createProposal(id, options) {
+    return this.post(`/${id}/proposal`, options);
   }
 
   /**
    * Get proposal info
    * @param {String} id
-   * @param {String} name - proposal name
+   * @param {String} pid - proposal id
    * @returns {Promise<Proposal>}
    */
 
-  getProposalInfo(id, name) {
-    return this.get(`/${id}/proposal/${name}`);
+  getProposalInfo(id, pid) {
+    return this.get(`/${id}/proposal/${pid}`);
   }
 
   /**
    * Get proposal transaction
    * @param {String} id
-   * @param {String} name - proposal name
+   * @param {String} pid - proposal id
    * @param {Object} options
    * @param {Boolean} options.path - include input paths
    * @param {Boolean} options.tx - include input transactions
@@ -450,42 +449,42 @@ class MultisigClient extends WalletClient {
    * @returns {Promise<MTX>}
    */
 
-  getProposalMTX(id, name, options) {
-    return this.get(`/${id}/proposal/${name}/tx`, options);
+  getProposalMTX(id, pid, options) {
+    return this.get(`/${id}/proposal/${pid}/tx`, options);
   }
 
   /**
    * Approve proposal
    * @param {String} id
-   * @param {String} name
+   * @param {String} pid - proposal id
    * @param {Buffer[]} signatures
    * @returns {Promise<Proposal>}
    */
 
-  approveProposal(id, name, signatures) {
-    return this.post(`/${id}/proposal/${name}/approve`, { signatures });
+  approveProposal(id, pid, signatures) {
+    return this.post(`/${id}/proposal/${pid}/approve`, { signatures });
   }
 
   /**
    * Reject proposal
    * @param {String} id
-   * @param {String} name
+   * @param {String} pid - proposal id
    * @returns {Promise<Proposal>}
    */
 
-  rejectProposal(id, name) {
-    return this.post(`/${id}/proposal/${name}/reject`);
+  rejectProposal(id, pid) {
+    return this.post(`/${id}/proposal/${pid}/reject`);
   }
 
   /**
    * Send proposal tx
    * @param {String} id
-   * @param {String} name
+   * @param {String} pid - proposal id
    * @returns {Promise<TX>}
    */
 
-  sendProposal(id, name) {
-    return this.post(`/${id}/proposal/${name}/send`);
+  sendProposal(id, pid) {
+    return this.post(`/${id}/proposal/${pid}/send`);
   }
 }
 
@@ -733,67 +732,66 @@ class MultisigWallet extends EventEmitter {
 
   /**
    * Create proposal
-   * @param {String} name - proposal name
    * @param {Object} options - transaction options
    * @returns {Promise<Proposal>}
    */
 
-  createProposal(name, options) {
-    return this.client.createProposal(this.id, name, options);
+  createProposal(options) {
+    return this.client.createProposal(this.id, options);
   }
 
   /**
    * Get proposal info
-   * @param {String} name - proposal name
+   * @param {String} pid - proposal id
    * @returns {Promise<Proposal>}
    */
 
-  getProposalInfo(name) {
-    return this.client.getProposalInfo(this.id, name);
+  getProposalInfo(pid) {
+    return this.client.getProposalInfo(this.id, pid);
   }
 
   /**
    * Get proposal transaction
-   * @param {String} name - proposal name
+   * @param {String} pid - proposal id
    * @param {Object} options
    * @param {Boolean} options.path - include input paths
    * @param {Boolean} options.scripts - include multisig scripts
    * @returns {Promise<MTX>}
    */
 
-  getProposalMTX(name, options) {
-    return this.client.getProposalMTX(this.id, name, options);
+  getProposalMTX(pid, options) {
+    return this.client.getProposalMTX(this.id, pid, options);
   }
 
   /**
    * Approve proposal
-   * @param {String} name
+   * @param {String} pid - proposal id
    * @param {Buffer} tx - raw signed tx
    * @returns {Promise<Proposal>}
    */
 
-  approveProposal(name, tx) {
-    return this.client.approveProposal(this.id, name, tx);
+  approveProposal(pid, tx) {
+    return this.client.approveProposal(this.id, pid, tx);
   }
 
   /**
    * Reject proposal
-   * @param {String} name
+   * @param {String} pid - proposal id
    * @returns {Promise<Proposal>}
    */
 
-  rejectProposal(name) {
-    return this.client.rejectProposal(this.id, name);
+  rejectProposal(pid) {
+    return this.client.rejectProposal(this.id, pid);
   }
 
   /**
    * Send proposal tx
-   * @param {String} name
+   * @param {String} pid - proposal id
    * @returns {Promise<TX>}
    */
 
-  sendProposal(name) {
-    return this.client.sendProposal(this.id, name);
+  sendProposal(pid) {
+    return this.client.sendProposal(this.id, pid);
   }
 }
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -414,15 +414,16 @@ class MultisigHTTP extends Server {
     /*
      * Create proposal.
      */
-    this.put('/:id/proposal/:name', async (req, res) => {
+
+    this.post('/:id/proposal', async (req, res) => {
       const valid = Validator.fromRequest(req);
       const options = parseTXOptions(req, this.network);
-      const name = valid.str('name');
+      const memo = valid.str('memo');
 
       enforce(req.cosigner, 'Cosigner not found.');
 
       const proposal = await req.mswallet.createProposal(
-        name,
+        memo,
         req.cosigner,
         options
       );
@@ -437,10 +438,10 @@ class MultisigHTTP extends Server {
     /*
      * Get proposal info
      */
-    this.get('/:id/proposal/:name', async (req, res) => {
+    this.get('/:id/proposal/:pid', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const name = valid.str('name');
-      const proposal = await req.mswallet.getProposal(name);
+      const pid = valid.u32('pid');
+      const proposal = await req.mswallet.getProposal(pid);
 
       if (!proposal) {
         res.json(404);
@@ -454,16 +455,16 @@ class MultisigHTTP extends Server {
      * Get proposal mtx
      * TODO: Add option for returning previous transactions.
      */
-    this.get('/:id/proposal/:name/tx', async (req, res) => {
+    this.get('/:id/proposal/:pid/tx', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const name = valid.str('name');
+      const pid = valid.u32('pid');
 
       const getPaths = valid.bool('paths', false);
       const getScripts = valid.bool('scripts', false);
 
       let paths, txs, rings, scripts;
 
-      const mtx = await req.mswallet.getProposalMTX(name);
+      const mtx = await req.mswallet.getProposalMTX(pid);
 
       if (!mtx) {
         res.json(404);
@@ -505,9 +506,9 @@ class MultisigHTTP extends Server {
     /*
      * Approve proposal
      */
-    this.post('/:id/proposal/:name/approve', async (req, res) => {
+    this.post('/:id/proposal/:pid/approve', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const name = valid.str('name');
+      const pid = valid.u32('pid');
       const hexSigs = valid.array('signatures', []);
 
       enforce(hexSigs.length, 'Could not find signatures');
@@ -522,7 +523,7 @@ class MultisigHTTP extends Server {
       enforce(sigs && sigs.length > 0, 'Signatures not found.');
 
       const proposal = await req.mswallet.approveProposal(
-        name,
+        pid,
         req.cosigner,
         sigs
       );
@@ -538,12 +539,12 @@ class MultisigHTTP extends Server {
     /*
      * Reject proposal
      */
-    this.post('/:id/proposal/:name/reject', async (req, res) => {
+    this.post('/:id/proposal/:pid/reject', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const name = valid.str('name');
+      const pid = valid.u32('pid');
 
       const proposal = await req.mswallet.rejectProposal(
-        name,
+        pid,
         req.cosigner
       );
 
@@ -558,11 +559,11 @@ class MultisigHTTP extends Server {
     /*
      * Send proposal tx
      */
-    this.post('/:id/proposal/:name/send', async (req, res) => {
+    this.post('/:id/proposal/:pid/send', async (req, res) => {
       const valid = Validator.fromRequest(req);
-      const name = valid.str('name');
+      const pid = valid.u32('pid');
 
-      const tx = await req.mswallet.sendProposal(name);
+      const tx = await req.mswallet.sendProposal(pid);
 
       if (!tx) {
         res.json(404);

--- a/lib/http.js
+++ b/lib/http.js
@@ -510,6 +510,7 @@ class MultisigHTTP extends Server {
       const valid = Validator.fromRequest(req);
       const pid = valid.u32('pid');
       const hexSigs = valid.array('signatures', []);
+      const broadcast = valid.bool('broadcast', true);
 
       enforce(hexSigs.length, 'Could not find signatures');
 
@@ -533,7 +534,21 @@ class MultisigHTTP extends Server {
         return;
       }
 
-      res.json(200, proposalCosignerJSON(proposal, req.mswallet));
+      let broadcasted = false, tx;
+      if (proposal.isApproved() && broadcast) {
+        try {
+          tx = await req.mswallet.sendProposal(pid);
+          assert(tx, 'Could not broadcast approved proposal.');
+          broadcasted = true;
+        } catch (e) {
+          this.logger.debug(`Failed to broadcast ${e.message}`);
+        }
+      }
+
+      res.json(200, {
+        broadcasted,
+        proposal: proposalCosignerJSON(proposal, req.mswallet, tx)
+      });
     });
 
     /*

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -31,7 +31,6 @@ exports.msdb = {
  * Proposal Database layout:
  *  D -> proposal id depth
  *  p[pid] -> proposal
- *  i[name] -> proposal index
  *  t[pid] -> transaction (value is also store with proposal)
  *  e[pid] -> dummy (pending proposals)
  *  f[pid] -> dummy (finished proposals)
@@ -45,7 +44,6 @@ exports.proposaldb = {
 
   D: bdb.key('D'),
   p: bdb.key('p', ['uint32']),
-  i: bdb.key('i', ['ascii']),
   t: bdb.key('t', ['uint32']),
   e: bdb.key('e', ['uint32']),
   f: bdb.key('f', ['uint32']),

--- a/lib/primitives/proposal.js
+++ b/lib/primitives/proposal.js
@@ -11,6 +11,7 @@ const bcoin = require('bcoin');
 const {encoding, Struct} = require('bufio');
 const {Outpoint, TX} = bcoin;
 const Cosigner = require('./cosigner');
+const util = require('../utils/common');
 const layout = require('../layout').proposaldb;
 
 /**
@@ -77,6 +78,8 @@ const statusIsApproved = (s) => {
  * @property {Number} author
  * @property {TX?} tx
  * @property {status} status
+ * @property {Number} createdAt - timestamp (seconds)
+ * @property {Number} closedAt - timestamp (seconds) / rejected or approved.
  * @property {Number} m
  * @property {Number} n
  * @property {Number[]} approvals
@@ -98,6 +101,8 @@ class Proposal extends Struct {
     this.id = 0;
     this.memo = '';
     this.author = 0;
+    this.createdAt = util.now();
+    this.closedAt = 0;
 
     this.status = status.PROGRESS;
 
@@ -134,6 +139,20 @@ class Proposal extends Struct {
       this.status = options.status;
     }
 
+    if (options.createdAt != null) {
+      assert(isU32(options.createdAt), 'createdAt must be u32.');
+      this.createdAt = options.createdAt;
+    }
+
+    if (options.closedAt != null) {
+      assert(!statusIsPending(options.status),
+        'Proposal is still pending.'
+      );
+
+      assert(isU32(options.closedAt), 'closedAt must be u32.');
+      this.closedAt = options.closedAt;
+    }
+
     this.id = options.id;
     this.memo = options.memo;
     this.author = options.author;
@@ -167,6 +186,9 @@ class Proposal extends Struct {
       author: this.author,
       approvals: this.approvals.toJSON(),
       rejections: this.rejections.toJSON(),
+      createdAt: this.createdAt,
+      rejectedAt: this.isRejected() ? this.closedAt : null,
+      approvedAt: this.isApproved() ? this.closedAt : null,
       m: this.m,
       n: this.n,
       statusCode: this.status,
@@ -202,7 +224,21 @@ class Proposal extends Struct {
     assert(json.n > 1, 'n must be more than 1.');
     assert(json.m >= 1 && json.m <= json.n,
       'm must be between 1 and n.');
+    assert(isU32(json.createdAt), 'createdAt must be u32.');
     assert(statusByVal[json.statusCode], 'Incorrect status code.');
+    assert(!json.rejectedAt || !this.approvedAt,
+      'Incorrect rejectedAt or approvedAt'
+    );
+
+    if (json.rejectedAt != null) {
+      assert(isU32(json.rejectedAt), 'rejectedAt must be u32.');
+      this.closedAt = this.rejectedAt;
+    }
+
+    if (json.approvedAt != null) {
+      assert(isU32(json.approvedAt), 'approvedAt must be u32.');
+      this.closedAt = this.approvedAt;
+    }
 
     this.id = json.id;
     this.memo = json.memo;
@@ -211,6 +247,7 @@ class Proposal extends Struct {
     this.status = json.statusCode;
 
     this.author = json.author;
+    this.createdAt = json.createdAt;
 
     // NOTE: Approvals won't store signatures into JSON
     this.approvals = ApprovalsMapRecord.fromJSON(json.approvals);
@@ -239,6 +276,8 @@ class Proposal extends Struct {
     size += this.memo.length;
     size += 1; // status
     size += 1; // author
+    size += 4; // createdAt
+    size += 4; // closedAt
 
     size += this.approvals.getSize();
     size += this.rejections.getSize();
@@ -258,6 +297,8 @@ class Proposal extends Struct {
     bw.writeBytes(Buffer.from(this.memo, 'utf8'));
     bw.writeU8(this.status);
     bw.writeU8(this.author);
+    bw.writeU32(this.createdAt);
+    bw.writeU32(this.closedAt);
 
     this.approvals.toWriter(bw);
     this.rejections.toWriter(bw);
@@ -278,6 +319,8 @@ class Proposal extends Struct {
     this.memo = br.readBytes(length).toString('utf8');
     this.status = br.readU8();
     this.author = br.readU8();
+    this.createdAt = br.readU32();
+    this.closedAt = br.readU32();
 
     this.approvals.fromReader(br);
     this.rejections.fromReader(br);
@@ -302,6 +345,8 @@ class Proposal extends Struct {
       && this.n === proposal.n
       && this.author === proposal.author
       && this.status === proposal.status
+      && this.createdAt === proposal.createdAt
+      && this.closedAt === proposal.closedAt
       && this.approvals.equals(proposal.approvals)
       && this.rejections.equals(proposal.rejections);
   }
@@ -346,11 +391,13 @@ class Proposal extends Struct {
 
     if (rejections >= critical) {
       this.status = status.REJECTED;
+      this.closedAt = util.now();
       return;
     }
 
     if (this.approvals.size === this.m) {
       this.status = status.APPROVED;
+      this.closedAt = util.now();
       return;
     }
   }

--- a/lib/primitives/proposal.js
+++ b/lib/primitives/proposal.js
@@ -125,7 +125,7 @@ class Proposal extends Struct {
     assert(options, 'Options are required.');
     assert(isU32(options.id), 'ID must be u32');
     assert(typeof options.memo === 'string', 'Bad proposal memo.');
-    assert(options.memo.length > 1 && options.memo.length < 160,
+    assert(options.memo.length > 1 && options.memo.length < 100,
       'Bad memo length.');
     assert(isU8(options.author), 'Author must be u8.');
     assert(isU8(options.n), 'n must be u8.');
@@ -217,7 +217,7 @@ class Proposal extends Struct {
     assert(isU32(json.id), 'ID must be u32.');
     assert(isU8(json.author), 'Author must be u8.');
     assert(typeof json.memo === 'string', 'Bad proposal memo.');
-    assert(json.memo.length > 1 && json.memo.length < 160,
+    assert(json.memo.length > 1 && json.memo.length < 100,
       'Bad memo length.');
     assert(isU8(json.n), 'n must be u8.');
     assert(isU8(json.m), 'm must be u8.');
@@ -293,8 +293,7 @@ class Proposal extends Struct {
 
   write(bw) {
     bw.writeU32(this.id);
-    bw.writeU8(this.memo.length);
-    bw.writeBytes(Buffer.from(this.memo, 'utf8'));
+    bw.writeVarBytes(Buffer.from(this.memo, 'utf8'));
     bw.writeU8(this.status);
     bw.writeU8(this.author);
     bw.writeU32(this.createdAt);
@@ -315,8 +314,7 @@ class Proposal extends Struct {
   read(br) {
     this.id = br.readU32();
 
-    const length = br.readU8();
-    this.memo = br.readBytes(length).toString('utf8');
+    this.memo = br.readVarBytes().toString('utf8');
     this.status = br.readU8();
     this.author = br.readU8();
     this.createdAt = br.readU32();

--- a/lib/primitives/proposal.js
+++ b/lib/primitives/proposal.js
@@ -9,7 +9,6 @@ const assert = require('bsert');
 const {enforce} = assert;
 const bcoin = require('bcoin');
 const {encoding, Struct} = require('bufio');
-const {common} = bcoin.wallet;
 const {Outpoint, TX} = bcoin;
 const Cosigner = require('./cosigner');
 const layout = require('../layout').proposaldb;
@@ -74,7 +73,7 @@ const statusIsApproved = (s) => {
  * Payment proposal
  * @extends {bufio#Struct}
  * @property {Number} id
- * @property {String} name
+ * @property {String} memo
  * @property {Number} author
  * @property {TX?} tx
  * @property {status} status
@@ -88,8 +87,7 @@ class Proposal extends Struct {
   /**
    * Create proposal
    * @param {String} options
-   * @param {String} options.name
-   * @param {String} [options.description='']
+   * @param {String} options.memo
    * @param {Cosigner} options.author
    * @param {TX} options.tx
    */
@@ -98,7 +96,7 @@ class Proposal extends Struct {
     super();
 
     this.id = 0;
-    this.name = '';
+    this.memo = '';
     this.author = 0;
 
     this.status = status.PROGRESS;
@@ -121,8 +119,9 @@ class Proposal extends Struct {
   fromOptions(options) {
     assert(options, 'Options are required.');
     assert(isU32(options.id), 'ID must be u32');
-    assert(options.name, 'Name is required.');
-    assert(common.isName(options.name), 'Bad proposal name.');
+    assert(typeof options.memo === 'string', 'Bad proposal memo.');
+    assert(options.memo.length > 1 && options.memo.length < 160,
+      'Bad memo length.');
     assert(isU8(options.author), 'Author must be u8.');
     assert(isU8(options.n), 'n must be u8.');
     assert(isU8(options.m), 'm must be u8.');
@@ -136,7 +135,7 @@ class Proposal extends Struct {
     }
 
     this.id = options.id;
-    this.name = options.name;
+    this.memo = options.memo;
     this.author = options.author;
 
     this.m = options.m;
@@ -163,7 +162,7 @@ class Proposal extends Struct {
 
     return {
       id: this.id,
-      name: this.name,
+      memo: this.memo,
       tx: txhex,
       author: this.author,
       approvals: this.approvals.toJSON(),
@@ -195,8 +194,9 @@ class Proposal extends Struct {
     assert(json, 'Options are required.');
     assert(isU32(json.id), 'ID must be u32.');
     assert(isU8(json.author), 'Author must be u8.');
-    assert(json.name, 'Name is required.');
-    assert(common.isName(json.name), 'Bad proposal name.');
+    assert(typeof json.memo === 'string', 'Bad proposal memo.');
+    assert(json.memo.length > 1 && json.memo.length < 160,
+      'Bad memo length.');
     assert(isU8(json.n), 'n must be u8.');
     assert(isU8(json.m), 'm must be u8.');
     assert(json.n > 1, 'n must be more than 1.');
@@ -205,7 +205,7 @@ class Proposal extends Struct {
     assert(statusByVal[json.statusCode], 'Incorrect status code.');
 
     this.id = json.id;
-    this.name = json.name;
+    this.memo = json.memo;
     this.n = json.n;
     this.m = json.m;
     this.status = json.statusCode;
@@ -235,8 +235,8 @@ class Proposal extends Struct {
 
   getSize() {
     let size = 4; // id
-    size += 1; // name size
-    size += this.name.length;
+    size += 1; // memo size (1 byte < 255)
+    size += this.memo.length;
     size += 1; // status
     size += 1; // author
 
@@ -254,8 +254,8 @@ class Proposal extends Struct {
 
   write(bw) {
     bw.writeU32(this.id);
-    bw.writeU8(this.name.length);
-    bw.writeBytes(Buffer.from(this.name, 'utf8'));
+    bw.writeU8(this.memo.length);
+    bw.writeBytes(Buffer.from(this.memo, 'utf8'));
     bw.writeU8(this.status);
     bw.writeU8(this.author);
 
@@ -275,7 +275,7 @@ class Proposal extends Struct {
     this.id = br.readU32();
 
     const length = br.readU8();
-    this.name = br.readBytes(length).toString('utf8');
+    this.memo = br.readBytes(length).toString('utf8');
     this.status = br.readU8();
     this.author = br.readU8();
 
@@ -297,7 +297,7 @@ class Proposal extends Struct {
 
   equals(proposal) {
     return this.id === proposal.id
-      && this.name === proposal.name
+      && this.memo === proposal.memo
       && this.m === proposal.m
       && this.n === proposal.n
       && this.author === proposal.author
@@ -506,22 +506,6 @@ class Proposal extends Struct {
   }
 
   /**
-   * @async
-   * @param {String} name
-   * @returns {Promise<Number>}
-   */
-
-  static async getPID(db, name) {
-    const pid = await db.get(layout.i.encode(name));
-
-    if (!pid)
-      return -1;
-
-    assert(pid.length === 4);
-    return pid.readUInt32LE(0, true);
-  }
-
-  /**
    * Has pid
    * @async
    * @param {Number} pid
@@ -530,17 +514,6 @@ class Proposal extends Struct {
 
   static has(db, pid) {
     return db.has(layout.p.encode(pid));
-  }
-
-  /**
-   * Has name
-   * @async
-   * @param {String} id
-   * @returns {Promise<Boolean>}
-   */
-
-  static hasName(db, name) {
-    return db.has(layout.i.encode(name));
   }
 
   /**
@@ -631,10 +604,8 @@ class Proposal extends Struct {
 
   static saveProposal(b, proposal) {
     const pid = proposal.id;
-    const name = proposal.name;
 
     b.put(layout.p.encode(pid), proposal.toRaw());
-    b.put(layout.i.encode(name), fromU32(pid));
 
     if (proposal.isPending()) {
       b.put(layout.e.encode(pid));

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -12,6 +12,7 @@ const {Outpoint, MTX} = require('bcoin');
 const MultisigMTX = require('./primitives/mtx');
 const Proposal = require('./primitives/proposal');
 const {MapLock, Lock} = require('bmutex');
+const util = require('./utils/common');
 const layout = require('./layout').proposaldb;
 
 /**
@@ -131,20 +132,18 @@ class ProposalDB {
   }
 
   /**
-   * Resolve id or name
-   * @param {String|Number} id
+   * Resolve id
+   * @param {Number} id
    * @returns {Promise<Number>}
    */
 
   async ensurePID(id) {
-    if (typeof id === 'number') {
-      if (await Proposal.has(this.bucket, id))
-        return id;
+    assert(typeof id === 'number');
 
-      return -1;
-    }
+    if (await Proposal.has(this.bucket, id))
+      return id;
 
-    return Proposal.getPID(this.bucket, id);
+    return -1;
   }
 
   /**
@@ -330,17 +329,17 @@ class ProposalDB {
 
   /**
    * Create proposal
-   * @param {String} name
+   * @param {String} memo
    * @param {Cosigner} cosigner
    * @param {MTX} mtx
    * @returns {Promise<Proposal>}
    */
 
-  async createProposal(name, cosigner, mtx) {
+  async createProposal(memo, cosigner, mtx) {
     const unlock = await this.writeLock.lock();
 
     try {
-      return this._createProposal(name, cosigner, mtx);
+      return this._createProposal(memo, cosigner, mtx);
     } finally {
       unlock();
     }
@@ -348,17 +347,14 @@ class ProposalDB {
 
   /**
    * Create proposal without lock
-   * @param {String} name
+   * @param {String} memo
    * @param {Cosigner} cosigner
    * @param {MTX} mtx
    * @returns {Promise<Proposal>}
    */
 
-  async _createProposal(name, cosigner, mtx) {
+  async _createProposal(memo, cosigner, mtx) {
     assert(mtx instanceof MTX);
-
-    if (await Proposal.hasName(this.bucket, name))
-      throw new Error('Proposal with that name already exists.');
 
     const b = this.bucket.batch();
     const id = this.depth;
@@ -371,7 +367,7 @@ class ProposalDB {
     //  Rings, Paths ? (We are storing coins for reorgs).
     const proposal = Proposal.fromOptions({
       id: id,
-      name: name,
+      memo: memo,
       author: cosigner.id,
       m: this.wallet.m,
       n: this.wallet.n
@@ -399,7 +395,7 @@ class ProposalDB {
 
   /**
    * Reject proposal
-   * @param {Number|String} id
+   * @param {Number} id
    * @param {Cosigner} cosigner
    * @returns {Promise<Proposal>}
    * @throws {Error}

--- a/lib/proposaldb.js
+++ b/lib/proposaldb.js
@@ -12,7 +12,6 @@ const {Outpoint, MTX} = require('bcoin');
 const MultisigMTX = require('./primitives/mtx');
 const Proposal = require('./primitives/proposal');
 const {MapLock, Lock} = require('bmutex');
-const util = require('./utils/common');
 const layout = require('./layout').proposaldb;
 
 /**

--- a/lib/utils/common.js
+++ b/lib/utils/common.js
@@ -1,0 +1,16 @@
+/*!
+ * common.js - common utility functions
+ * Copyright (c) 2018, The Bcoin Developers (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+'use strict';
+
+/**
+ * Get current time in unix time (seconds).
+ * @returns {Number}
+ */
+
+exports.now = function now() {
+  return Math.floor(Date.now() / 1000);
+};

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -582,17 +582,17 @@ class MultisigWallet {
   /**
    * Create proposal
    * @async
-   * @param {String} name
+   * @param {String} memo
    * @param {Cosigner} cosigner
    * @param {Object} txoptions
    * @returns {Proposal}
    */
 
-  async createProposal(name, cosigner, txoptions) {
+  async createProposal(memo, cosigner, txoptions) {
     const unlock = await this.coinLock.lock();
 
     try {
-      return this._createProposal(name, cosigner, txoptions);
+      return this._createProposal(memo, cosigner, txoptions);
     } finally {
       unlock();
     }
@@ -601,15 +601,15 @@ class MultisigWallet {
   /**
    * Create proposal without lock
    * @async
-   * @param {String} name
+   * @param {String} memo
    * @param {Cosigner} cosigner
    * @param {Object} txoptions
    * @returns {Proposal}
    */
 
-  async _createProposal(name, cosigner, txoptions) {
+  async _createProposal(memo, cosigner, txoptions) {
     const mtx = await this._createTX(txoptions);
-    const proposal = await this.pdb.createProposal(name, cosigner, mtx);
+    const proposal = await this.pdb.createProposal(memo, cosigner, mtx);
 
     return proposal;
   }
@@ -776,38 +776,38 @@ class MultisigWallet {
 
   /**
    * Reject proposal
-   * @param {Number|String} id
+   * @param {Number} id
    * @param {Cosigner} cosigner
    * @returns {Promise<Proposal>}
    * @throws {Error}
    */
 
-  rejectProposal(name, cosigner) {
-    return this.pdb.rejectProposal(name, cosigner);
+  rejectProposal(id, cosigner) {
+    return this.pdb.rejectProposal(id, cosigner);
   }
 
   /**
    * Approve proposal
-   * @param {Number|String} id
+   * @param {Number} id
    * @param {Cosigner} cosigner
    * @param {Buffer[]} signatures
    * @returns {Promise<Proposal>}
    * @throws {Error}
    */
 
-  approveProposal(name, cosigner, signatures) {
-    return this.pdb.approveProposal(name, cosigner, signatures);
+  approveProposal(id, cosigner, signatures) {
+    return this.pdb.approveProposal(id, cosigner, signatures);
   }
 
   /**
    * Broadcast proposal mtx.
-   * @param {Number|String} id
+   * @param {Number} id
    * @returns {Promise<TX>}
    * @throws {Error}
    */
 
-  sendProposal(name) {
-    return this.pdb.sendProposal(name);
+  sendProposal(id) {
+    return this.pdb.sendProposal(id);
   }
 
   /**

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -506,11 +506,13 @@ describe('HTTP', function () {
 
     const signatures = testUtils.getMTXSignatures(mtx, rings);
 
-    const proposal = await testWalletClient1.approveProposal(
+    const response = await testWalletClient1.approveProposal(
       WALLET_OPTIONS.id,
       pid2,
       signatures
     );
+
+    const proposal = response.proposal;
 
     assert.strictEqual(proposal.approvals.length, 1);
     assert.strictEqual(proposal.statusCode, Proposal.status.PROGRESS);
@@ -542,11 +544,13 @@ describe('HTTP', function () {
 
     const signatures = testUtils.getMTXSignatures(mtx, rings);
 
-    const proposal = await testWalletClient2.approveProposal(
+    const response = await testWalletClient2.approveProposal(
       WALLET_OPTIONS.id,
       pid2,
       signatures
     );
+
+    const proposal = response.proposal;
 
     // we are not spending it yet.
     await wdb.addBlock(walletUtils.nextBlock(wdb), []);

--- a/test/proposal-test.js
+++ b/test/proposal-test.js
@@ -13,7 +13,7 @@ const {hd} = require('bcoin');
 
 const TEST_OPTIONS = {
   id: 1,
-  name: 'test1',
+  memo: 'test1',
   m: 2,
   n: 3,
   author: 0


### PR DESCRIPTION
- Proposal now has memo, but it's not unique.
- Now we use ID for identification and requests instead of name
- Add createdAt and closedAt to proposals.
- Add broadcast option to `approveProposal` http call.

Closes #31, #29 

Proposal wont store `broadcast` as state, but http endpoint will return if it was broadcasted on approval.
Even if proposal had that state, would not mean much. It might have failed right away on the bcoin node side.