### PR TITLE
http: handle bad token

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -512,6 +512,12 @@ class MultisigHTTP extends Server {
       const hexSigs = valid.array('signatures', []);
       const broadcast = valid.bool('broadcast', true);
 
+      // handle case when admin token is used to join
+      if (!req.cosigner) {
+        res.json(404);
+        return;
+      }
+
       enforce(hexSigs.length, 'Could not find signatures');
 
       const sigs = hexSigs.map((sig) => {


### PR DESCRIPTION
Previously an error would happen if the admin token was used
because the auth middleware would succeed but it fails to
populate the `req` object with a `cosigner`. The error happens
further down the call stack in `mswallet.approveProposal`, where
an undefined `req.cosigner` is passed in.