### PR TITLE
feature: return input txs

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -472,6 +472,7 @@ class MultisigHTTP extends Server {
 
       const getPaths = valid.bool('paths', false);
       const getScripts = valid.bool('scripts', false);
+      const getTXs = valid.bool('txs', false);
 
       let paths, txs, rings, scripts;
 
@@ -493,9 +494,18 @@ class MultisigHTTP extends Server {
         scripts = rings.map(r => r.script);
       }
 
+      if (getTXs) {
+        txs = [];
+        for (const {prevout} of mtx.inputs) {
+          const {hash} = prevout;
+          const record = await req.wallet.getTX(hash);
+          txs.push(record.tx)
+        }
+      }
+
       res.json(200, {
         tx: mtx.getJSON(this.network),
-        txs: txs ? txs.map(t => t.toRaw('hex')) : null,
+        txs: txs ? txs.map(t => t.toRaw('hex').toString('hex')) : null,
 
         paths: paths ? paths.map((p) => {
           if (!p)

--- a/lib/http.js
+++ b/lib/http.js
@@ -499,7 +499,7 @@ class MultisigHTTP extends Server {
         for (const {prevout} of mtx.inputs) {
           const {hash} = prevout;
           const record = await req.wallet.getTX(hash);
-          txs.push(record.tx)
+          txs.push(record.tx);
         }
       }
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -505,7 +505,7 @@ class MultisigHTTP extends Server {
 
       res.json(200, {
         tx: mtx.getJSON(this.network),
-        txs: txs ? txs.map(t => t.toRaw('hex').toString('hex')) : null,
+        txs: txs ? txs.map(t => t.toRaw().toString('hex')) : null,
 
         paths: paths ? paths.map((p) => {
           if (!p)

--- a/test/http-test.js
+++ b/test/http-test.js
@@ -543,10 +543,12 @@ describe('HTTP', function () {
       assert.equal(output.value, input.coin.value);
 
       // assert that the scripts are equal
-      assert.equal(output.script.toRaw('hex').toString('hex'), input.coin.script);
+      assert.equal(
+        output.script.toRaw('hex').toString('hex'),
+        input.coin.script
+      );
     }
-  })
-
+  });
 
   it('should reject proposal', async () => {
     const rejectEvents = Promise.all([


### PR DESCRIPTION
Addresses https://github.com/bcoin-org/bmultisig/issues/38

This adds the ability to return input transactions when fetching the proposal mtx
I always find myself requesting those transactions anyways, so this allows it to happen in a single call.
Tests are added, along with comments in the tests