### PR TITLE
API: Breaking change to TX format

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -554,8 +554,6 @@ class MultisigHTTP extends Server {
       const getScripts = valid.bool('scripts', false);
       const getTXs = valid.bool('txs', false);
 
-      let paths, txs, rings, scripts;
-
       const mtx = await req.mswallet.getProposalMTX(pid);
 
       if (!mtx) {
@@ -563,17 +561,13 @@ class MultisigHTTP extends Server {
         return;
       }
 
-      if (getPaths)
-        paths = await req.mswallet.getInputPaths(mtx);
+      const jtx = mtx.getJSON(this.network);
+      let account;
+      if (getScripts)
+        account = await req.wallet.getAccount();
 
-      if (getScripts && rings)
-        scripts = rings.map(r => r.script);
-
-      if (getScripts && !rings) {
-        const rings = await req.mswallet.deriveInputs(mtx, paths);
-        scripts = rings.map(r => r.script);
-      }
-
+      // Return raw txs
+      let txs;
       if (getTXs) {
         txs = [];
         for (const {prevout} of mtx.inputs) {
@@ -583,24 +577,36 @@ class MultisigHTTP extends Server {
         }
       }
 
-      res.json(200, {
-        tx: mtx.getJSON(this.network),
-        txs: txs ? txs.map(t => t.toRaw().toString('hex')) : null,
+      // Include additional details on each input
+      let i = 0;
+      for (const input of mtx.inputs) {
+        const coin = mtx.view.getOutputFor(input);
+        const address = input.getAddress(coin);
+        const p = await req.wallet.getPath(address);
 
-        paths: paths ? paths.map((p) => {
-          if (!p)
-            return null;
-
-          return {
+        if (getPaths) {
+          jtx.inputs[i].coin.path = p ? {
             branch: p.branch,
             index: p.index,
             receive: p.branch === 0,
             change: p.branch === 1,
             nested: p.branch === 2
-          };
-        }) : null,
+          } : null;
+        }
 
-        scripts: scripts ? scripts.map(s => s.toRaw().toString('hex')) : null
+        if (getScripts) {
+          const ring = account.derivePath(p);
+          jtx.inputs[i].coin.script = ring ?
+            ring.script.toRaw().toString('hex') :
+            null;
+        }
+
+        ++i;
+      }
+
+      res.json(200, {
+        tx: jtx,
+        txs: txs ? txs.map(t => t.toRaw().toString('hex')) : null
       });
     });
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -562,17 +562,15 @@ class MultisigHTTP extends Server {
       }
 
       const jtx = mtx.getJSON(this.network);
-      let account;
-      if (getScripts)
-        account = await req.wallet.getAccount();
 
       // Include additional details on each input
+      let account;
       let i = 0;
       for (const input of mtx.inputs) {
         if (getTXs) {
           const hash = input.prevout.hash;
           const {tx} = await req.wallet.getTX(hash);
-          jtx.inputs[i].tx = tx;
+          jtx.inputs[i].tx = tx.toRaw().toString('hex');
         }
 
         if (!getPaths && !getScripts) {
@@ -595,6 +593,9 @@ class MultisigHTTP extends Server {
         }
 
         if (getScripts) {
+          if (!account)
+            account = await req.mswallet.getAccount();
+
           const ring = account.derivePath(p);
           jtx.inputs[i].coin.script = ring ?
             ring.script.toRaw().toString('hex') :

--- a/lib/http.js
+++ b/lib/http.js
@@ -565,18 +565,15 @@ class MultisigHTTP extends Server {
 
       // Include additional details on each input
       let account;
-      let i = 0;
-      for (const input of mtx.inputs) {
+      for (const [i, input] of mtx.inputs.entries()) {
         if (getTXs) {
           const hash = input.prevout.hash;
           const {tx} = await req.wallet.getTX(hash);
           jtx.inputs[i].tx = tx.toRaw().toString('hex');
         }
 
-        if (!getPaths && !getScripts) {
-          ++i;
+        if (!getPaths && !getScripts)
           continue;
-        }
 
         const coin = mtx.view.getOutputFor(input);
         const address = input.getAddress(coin);
@@ -601,8 +598,6 @@ class MultisigHTTP extends Server {
             ring.script.toRaw().toString('hex') :
             null;
         }
-
-        ++i;
       }
 
       res.json(200, { tx: jtx });

--- a/lib/http.js
+++ b/lib/http.js
@@ -566,20 +566,20 @@ class MultisigHTTP extends Server {
       if (getScripts)
         account = await req.wallet.getAccount();
 
-      // Return raw txs
-      let txs;
-      if (getTXs) {
-        txs = [];
-        for (const {prevout} of mtx.inputs) {
-          const {hash} = prevout;
-          const record = await req.wallet.getTX(hash);
-          txs.push(record.tx);
-        }
-      }
-
       // Include additional details on each input
       let i = 0;
       for (const input of mtx.inputs) {
+        if (getTXs) {
+          const hash = input.prevout.hash;
+          const {tx} = await req.wallet.getTX(hash);
+          jtx.inputs[i].tx = tx;
+        }
+
+        if (!getPaths && !getScripts) {
+          ++i;
+          continue;
+        }
+
         const coin = mtx.view.getOutputFor(input);
         const address = input.getAddress(coin);
         const p = await req.wallet.getPath(address);
@@ -604,10 +604,7 @@ class MultisigHTTP extends Server {
         ++i;
       }
 
-      res.json(200, {
-        tx: jtx,
-        txs: txs ? txs.map(t => t.toRaw().toString('hex')) : null
-      });
+      res.json(200, { tx: jtx });
     });
 
     /*

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -737,9 +737,20 @@ class MultisigWallet extends EventEmitter {
    */
 
   async getInputPaths(mtx) {
-    const hashes = mtx.getInputHashes();
-    const paths = [];
+    // mtx.getInputHashes returns de-duped set
+    // we require a full set to match mtx inputs
+    const hashes = [];
+    for (const input of mtx.inputs) {
+      const coin = mtx.view.getOutputFor(input);
+      const addr = input.getAddress(coin);
 
+      if (!addr)
+        continue;
+
+      hashes.push(addr.getHash());
+    }
+
+    const paths = [];
     for (const hash of hashes) {
       const path = await this.wallet.getPath(hash);
 


### PR DESCRIPTION
In current API response, the top-level objects are stand-alone, and assumed to
map to `tx.inputs` based on array index. However, for `paths` and `scripts`,
this does not work, since they will be de-duped by address hash. In cases
where a TX has multiple coins per address hash, this results
in a response that can't be properly understood by the client.

The proposed change merges all of these top-level objects into each
input in the TX object. This additional data will not be handled by
default bcoin primitives. This means clients must be aware of how
to manually parse out this additional information from the JSON.

Example Client Usage:
https://github.com/bcoin-org/bsigner/commit/2516dc0e27a8f1fdb00c6df8e832480700222f40

This is the ideal API format, but perhaps not ideal in the context of
maintaining compatibility with bcoin primitives. Is this important?
